### PR TITLE
feat: Single resource page with Tab content

### DIFF
--- a/ngui/ui/src/components/CollapsableTableCell/CollapsableTableCell.tsx
+++ b/ngui/ui/src/components/CollapsableTableCell/CollapsableTableCell.tsx
@@ -50,7 +50,7 @@ const renderItems =
         return (
           <KeyValueLabel
             dataTestIds={{ key: `lbl_tags_key_${dataTestIdIndex}`, value: `lbl_tags_value_${dataTestIdIndex}` }}
-            isBoldKeyLabel={true}
+            isBoldKeyLabel
             sx={{ marginBottom: MPT_SPACING_2 }}
             key={displayedKey}
             keyText={displayedKey}
@@ -66,7 +66,7 @@ const renderItems =
         return (
           <KeyValueLabel
             dataTestIds={{ key: `lbl_tags_key_${dataTestIdIndex}`, value: `lbl_tags_value_${dataTestIdIndex}` }}
-            isBoldKeyLabel={true}
+            isBoldKeyLabel
             sx={{ marginBottom: MPT_SPACING_2 }}
             keyText={key}
             value={<CopyText textToCopy={textToCopy}>{cutValue}</CopyText>}

--- a/ngui/ui/src/components/CollapsableTableCell/CollapsableTableCell.tsx
+++ b/ngui/ui/src/components/CollapsableTableCell/CollapsableTableCell.tsx
@@ -3,6 +3,7 @@ import CopyTextComponent from "components/CopyText";
 import ExpandableList from "components/ExpandableList";
 import KeyValueLabel from "components/KeyValueLabel/KeyValueLabel";
 import Tooltip from "components/Tooltip";
+import { MPT_SPACING_2 } from "utils/layouts";
 import { sliceByLimitWithEllipsis } from "utils/strings";
 
 /**
@@ -49,6 +50,8 @@ const renderItems =
         return (
           <KeyValueLabel
             dataTestIds={{ key: `lbl_tags_key_${dataTestIdIndex}`, value: `lbl_tags_value_${dataTestIdIndex}` }}
+            isBoldKeyLabel={true}
+            sx={{ marginBottom: MPT_SPACING_2 }}
             key={displayedKey}
             keyText={displayedKey}
             value={<CopyText textToCopy={textToCopy}>{value}</CopyText>}
@@ -63,6 +66,8 @@ const renderItems =
         return (
           <KeyValueLabel
             dataTestIds={{ key: `lbl_tags_key_${dataTestIdIndex}`, value: `lbl_tags_value_${dataTestIdIndex}` }}
+            isBoldKeyLabel={true}
+            sx={{ marginBottom: MPT_SPACING_2 }}
             keyText={key}
             value={<CopyText textToCopy={textToCopy}>{cutValue}</CopyText>}
           />

--- a/ngui/ui/src/components/OrganizationConstraintsCard/OrganizationConstraintsCard.tsx
+++ b/ngui/ui/src/components/OrganizationConstraintsCard/OrganizationConstraintsCard.tsx
@@ -50,6 +50,7 @@ const ConstraintsTable = ({ constraints }) => {
 
 const OrganizationConstraintsCard = ({ constraints, isLoading = false }) => (
   <WrapperCard
+    variant="shadow"
     needAlign
     title={<FormattedMessage id="policyViolations" />}
     dataTestIds={{

--- a/ngui/ui/src/components/OrganizationExpenses/OrganizationExpenses.tsx
+++ b/ngui/ui/src/components/OrganizationExpenses/OrganizationExpenses.tsx
@@ -57,6 +57,7 @@ const OrganizationExpenses = ({ data, isLoading }) => {
 
   return (
     <WrapperCard
+      variant="shadow"
       needAlign
       title={<FormattedMessage id="organizationExpenses" />}
       titleButton={{

--- a/ngui/ui/src/components/PoolsRequiringAttentionCard/PoolsRequiringAttentionCard.tsx
+++ b/ngui/ui/src/components/PoolsRequiringAttentionCard/PoolsRequiringAttentionCard.tsx
@@ -157,6 +157,7 @@ const PoolsRequiringAttentionCard = ({ withExceededLimit, withForecastedOverspen
 
   return (
     <WrapperCard
+      variant="shadow"
       needAlign
       title={<FormattedMessage id="poolsRequiringAttention" />}
       titleButton={{

--- a/ngui/ui/src/components/RecentModelsCard/RecentModelsCard.tsx
+++ b/ngui/ui/src/components/RecentModelsCard/RecentModelsCard.tsx
@@ -68,6 +68,7 @@ const RecentModelsCard = ({ models, isLoading = false }: RecentModelsCardProps) 
 
   return (
     <WrapperCard
+      variant="shadow"
       needAlign
       title={
         <Box display="flex" alignItems="center">

--- a/ngui/ui/src/components/RecentTasksCard/RecentTasksCard.tsx
+++ b/ngui/ui/src/components/RecentTasksCard/RecentTasksCard.tsx
@@ -59,6 +59,7 @@ const RecentTasksCard = ({ tasks, isLoading = false }) => {
 
   return (
     <WrapperCard
+      variant="shadow"
       needAlign
       title={
         <Box display="flex" alignItems="center">

--- a/ngui/ui/src/components/RecommendationsCard/RecommendationsCard.tsx
+++ b/ngui/ui/src/components/RecommendationsCard/RecommendationsCard.tsx
@@ -41,6 +41,7 @@ const RecommendationsCard = ({
 
   return (
     <WrapperCard
+      variant="shadow"
       needAlign
       title={<FormattedMessage id="recommendations" />}
       titleButton={{

--- a/ngui/ui/src/components/Resource/Resource.tsx
+++ b/ngui/ui/src/components/Resource/Resource.tsx
@@ -6,6 +6,7 @@ import LaunchOutlinedIcon from "@mui/icons-material/LaunchOutlined";
 import MediationOutlinedIcon from "@mui/icons-material/MediationOutlined";
 import { Link } from "@mui/material";
 import Grid from "@mui/material/Grid";
+import { Box } from "@mui/system";
 import { FormattedMessage } from "react-intl";
 import { useNavigate, Link as RouterLink } from "react-router-dom";
 import ActionBar from "components/ActionBar";
@@ -33,7 +34,6 @@ import { isEmpty as isEmptyArray, getSumByObjectKey } from "utils/arrays";
 import { SUMMARY_VALUE_COMPONENT_TYPES, RESOURCE_PAGE_TABS } from "utils/constants";
 import { SPACING_2, MPT_SPACING_3 } from "utils/layouts";
 import { getCloudResourceIdentifier, getResourceDisplayedName } from "utils/resources";
-import { Box } from "@mui/system";
 
 const {
   DETAILS: DETAILS_TAB,
@@ -403,23 +403,23 @@ const Resource = ({ resource, isGetResourceLoading, patchResource, isLoadingPatc
       <PageContentWrapper>
         <Grid container spacing={SPACING_2}>
           <Grid container item xs={12}>
-            <SummaryGrid summaryData={getSummaryData} summaryStyle="customBox"     />
+            <SummaryGrid summaryData={getSummaryData} summaryStyle="customBox" />
           </Grid>
           <Grid item xs={12} className={"MTPBoxShadowRoot"}>
             <Box>
-            <TabsWrapper
-              headerSx={{ margin: `-${MPT_SPACING_3} -${MPT_SPACING_3} 0`, padding: `0 ${MPT_SPACING_3}` }}
-              isLoading={isGetResourceLoading || isLoadingPatch}
-              tabsProps={{
-                tabs,
-                defaultTab: DETAILS_TAB,
-                activeTab,
-                handleChange,
-                name: "resources-details"
-              }}
-            />
+              <TabsWrapper
+                headerSx={{ margin: `-${MPT_SPACING_3} -${MPT_SPACING_3} 0`, padding: `0 ${MPT_SPACING_3}` }}
+                isLoading={isGetResourceLoading || isLoadingPatch}
+                tabsProps={{
+                  tabs,
+                  defaultTab: DETAILS_TAB,
+                  activeTab,
+                  handleChange,
+                  name: "resources-details"
+                }}
+              />
             </Box>
-          </Grid>          
+          </Grid>
         </Grid>
       </PageContentWrapper>
     </>

--- a/ngui/ui/src/components/Resource/Resource.tsx
+++ b/ngui/ui/src/components/Resource/Resource.tsx
@@ -31,8 +31,9 @@ import { RESOURCES, getCreateResourceAssignmentRuleUrl } from "urls";
 import { trackEvent, GA_EVENT_CATEGORIES } from "utils/analytics";
 import { isEmpty as isEmptyArray, getSumByObjectKey } from "utils/arrays";
 import { SUMMARY_VALUE_COMPONENT_TYPES, RESOURCE_PAGE_TABS } from "utils/constants";
-import { SPACING_2 } from "utils/layouts";
+import { SPACING_2, MPT_SPACING_3 } from "utils/layouts";
 import { getCloudResourceIdentifier, getResourceDisplayedName } from "utils/resources";
+import { Box } from "@mui/system";
 
 const {
   DETAILS: DETAILS_TAB,
@@ -402,10 +403,12 @@ const Resource = ({ resource, isGetResourceLoading, patchResource, isLoadingPatc
       <PageContentWrapper>
         <Grid container spacing={SPACING_2}>
           <Grid container item xs={12}>
-            <SummaryGrid summaryData={getSummaryData} />
+            <SummaryGrid summaryData={getSummaryData} summaryStyle="customBox"     />
           </Grid>
-          <Grid item xs={12}>
+          <Grid item xs={12} className={"MTPBoxShadowRoot"}>
+            <Box>
             <TabsWrapper
+              headerSx={{ margin: `-${MPT_SPACING_3} -${MPT_SPACING_3} 0`, padding: `0 ${MPT_SPACING_3}` }}
               isLoading={isGetResourceLoading || isLoadingPatch}
               tabsProps={{
                 tabs,
@@ -415,7 +418,8 @@ const Resource = ({ resource, isGetResourceLoading, patchResource, isLoadingPatc
                 name: "resources-details"
               }}
             />
-          </Grid>
+            </Box>
+          </Grid>          
         </Grid>
       </PageContentWrapper>
     </>

--- a/ngui/ui/src/components/ResourceDetails/ResourceDetails.tsx
+++ b/ngui/ui/src/components/ResourceDetails/ResourceDetails.tsx
@@ -11,12 +11,12 @@ import ResourceTypeLabel from "components/ResourceTypeLabel";
 import SubTitle from "components/SubTitle";
 import { RESOURCE_PAGE_TABS } from "utils/constants";
 import { formatUTC, EN_FULL_FORMAT } from "utils/datetime";
-import { SPACING_2 } from "utils/layouts";
+import { MPT_SPACING_2, SPACING_2 } from "utils/layouts";
 import { MetadataNodes } from "utils/metadata";
 import { isEmpty } from "utils/objects";
 import CollapsableTableCell from "../CollapsableTableCell";
 
-const renderKeyValueLabels = (options) => options.map((opt) => <KeyValueLabel key={opt.keyMessageId} {...opt} />);
+const renderKeyValueLabels = (options) => options.map((opt) => <KeyValueLabel sx={{ marginBottom: MPT_SPACING_2 }} isBoldKeyLabel={true} key={opt.keyMessageId} {...opt} />);
 
 const getIdLabelDefinition = ({ cloudResourceIdentifier, isActive }) => ({
   value: (
@@ -320,14 +320,14 @@ const ResourceDetails = (props) => {
   return (
     <Grid container spacing={SPACING_2}>
       <Grid item xs={12} sm={columnSize}>
-        <SubTitle>
+        <SubTitle fontWeight="bold" sx={{ marginBottom: "20px" }}>
           <FormattedMessage id="resourceProperties" />
         </SubTitle>
         {resourceProperties}
       </Grid>
       {shouldRenderMetadata && (
         <Grid item xs={12} sm={columnSize}>
-          <SubTitle>
+          <SubTitle fontWeight="bold" sx={{ marginBottom: "20px" }}>
             <FormattedMessage id="resourceMetadata" />
           </SubTitle>
           <CollapsableTableCell maxRows={10} tags={metadataTags} sorted={false} />
@@ -335,7 +335,7 @@ const ResourceDetails = (props) => {
       )}
       {shouldRenderTagsTable && (
         <Grid item xs={12} sm={columnSize}>
-          <SubTitle>
+          <SubTitle fontWeight="bold" sx={{ marginBottom: "20px" }}>
             <FormattedMessage id="tags" />
           </SubTitle>
           <CollapsableTableCell tags={tags} />

--- a/ngui/ui/src/components/ResourceDetails/ResourceDetails.tsx
+++ b/ngui/ui/src/components/ResourceDetails/ResourceDetails.tsx
@@ -16,7 +16,8 @@ import { MetadataNodes } from "utils/metadata";
 import { isEmpty } from "utils/objects";
 import CollapsableTableCell from "../CollapsableTableCell";
 
-const renderKeyValueLabels = (options) => options.map((opt) => <KeyValueLabel sx={{ marginBottom: MPT_SPACING_2 }} isBoldKeyLabel={true} key={opt.keyMessageId} {...opt} />);
+const renderKeyValueLabels = (options) =>
+  options.map((opt) => <KeyValueLabel sx={{ marginBottom: MPT_SPACING_2 }} isBoldKeyLabel key={opt.keyMessageId} {...opt} />);
 
 const getIdLabelDefinition = ({ cloudResourceIdentifier, isActive }) => ({
   value: (

--- a/ngui/ui/src/components/ResourceMetrics/MetricCard/MetricCard.tsx
+++ b/ngui/ui/src/components/ResourceMetrics/MetricCard/MetricCard.tsx
@@ -2,7 +2,7 @@ import WrapperCard from "components/WrapperCard";
 import MetricChart from "../MetricChart";
 
 const MetricCard = ({ title, isLoading, chartProps, dataTestIds = {} }) => (
-  <WrapperCard title={title} variant="outlined" dataTestIds={dataTestIds} needAlign>
+  <WrapperCard title={title} variant="clean" dataTestIds={dataTestIds} needAlign>
     <MetricChart isLoading={isLoading} {...chartProps} />
   </WrapperCard>
 );

--- a/ngui/ui/src/components/ResourceMetrics/ResourceMetrics.tsx
+++ b/ngui/ui/src/components/ResourceMetrics/ResourceMetrics.tsx
@@ -5,7 +5,7 @@ import { SPACING_2 } from "utils/layouts";
 import MetricCard from "./MetricCard";
 
 const GridItem = ({ children }) => (
-  <Grid xs={12} sm={6} md={6} lg={4} xl={3} item>
+  <Grid xs={12} sm={6} md={6} lg={6} xl={6} item>
     {children}
   </Grid>
 );

--- a/ngui/ui/src/components/TopResourcesExpensesCard/TopResourcesExpensesCard.tsx
+++ b/ngui/ui/src/components/TopResourcesExpensesCard/TopResourcesExpensesCard.tsx
@@ -139,6 +139,7 @@ const TopResourcesExpensesCard = ({ cleanExpenses, isLoading }) => {
   return (
     <WrapperCard
       needAlign
+      variant="shadow"
       title={
         <Box display="flex" alignItems="center">
           <Box mr={0.5}>

--- a/ngui/ui/src/components/WrapperCard/WrapperCard.styles.ts
+++ b/ngui/ui/src/components/WrapperCard/WrapperCard.styles.ts
@@ -1,5 +1,5 @@
 import { makeStyles } from "tss-react/mui";
-import { MPT_BOX_SHADOW, MPT_SPACING_2, MPT_SPACING_3 } from "../../utils/layouts";
+import { MPT_SPACING_3 } from "../../utils/layouts";
 
 const useStyles = makeStyles()((theme) => ({
   spacer: {
@@ -15,10 +15,6 @@ const useStyles = makeStyles()((theme) => ({
   card: {
     padding: MPT_SPACING_3
   },
-  // shadow: {
-  //   borderRadius: MPT_SPACING_2,
-  //   boxShadow: MPT_BOX_SHADOW
-  // },
   buttonLink: {
     "&:hover": {
       textDecoration: "none"

--- a/ngui/ui/src/components/WrapperCard/WrapperCard.styles.ts
+++ b/ngui/ui/src/components/WrapperCard/WrapperCard.styles.ts
@@ -15,10 +15,10 @@ const useStyles = makeStyles()((theme) => ({
   card: {
     padding: MPT_SPACING_3
   },
-  shadow: {
-    borderRadius: MPT_SPACING_2,
-    boxShadow: MPT_BOX_SHADOW
-  },
+  // shadow: {
+  //   borderRadius: MPT_SPACING_2,
+  //   boxShadow: MPT_BOX_SHADOW
+  // },
   buttonLink: {
     "&:hover": {
       textDecoration: "none"

--- a/ngui/ui/src/components/WrapperCard/WrapperCard.tsx
+++ b/ngui/ui/src/components/WrapperCard/WrapperCard.tsx
@@ -62,7 +62,7 @@ const WrapperCard = forwardRef(
     } = dataTestIds || {};
     const { show: showButton, href, link, messageId: buttonTextId } = button || {};
 
-    const mainCardClasses = cx(classes[className], needAlign ? classes.alignedWrapper : "", classes.shadow);
+    const mainCardClasses = cx(classes[className], needAlign ? classes.alignedWrapper : "");
 
     return (
       <>

--- a/ngui/ui/src/theme.ts
+++ b/ngui/ui/src/theme.ts
@@ -492,7 +492,7 @@ const getThemeConfig = (settings = {}) => {
         variants: [
           {
             props: { variant: "clean" },
-            style: ({ theme }) => ({
+            style: () => ({
               border: "none",
               borderRadius: 0,
               boxShadow: "none",
@@ -503,7 +503,7 @@ const getThemeConfig = (settings = {}) => {
           },
           {
             props: { variant: "shadow" },
-            style: ({ theme }) => ({
+            style: () => ({
               borderRadius: MPT_SPACING_2,
               boxShadow: MPT_BOX_SHADOW
             })

--- a/ngui/ui/src/theme.ts
+++ b/ngui/ui/src/theme.ts
@@ -486,6 +486,29 @@ const getThemeConfig = (settings = {}) => {
         }
       },
       MuiCard: {
+        defaultProps: {
+          variant: "outlined"
+        },
+        variants: [
+          {
+            props: { variant: "clean" },
+            style: ({ theme }) => ({
+              border: "none",
+              borderRadius: 0,
+              boxShadow: "none",
+              "& .MuiCardContent-root": {
+                padding: 0
+              }
+            })
+          },
+          {
+            props: { variant: "shadow" },
+            style: ({ theme }) => ({
+              borderRadius: MPT_SPACING_2,
+              boxShadow: MPT_BOX_SHADOW
+            })
+          }
+        ],
         styleOverrides: {
           root: {
             borderRadius: "16px" // Set your desired border-radius value

--- a/ngui/ui/src/utils/fonts.ts
+++ b/ngui/ui/src/utils/fonts.ts
@@ -64,15 +64,14 @@ const generateResponsiveFontSizes = (themeInput) => {
     ...theme.typography.subtitle1,
     fontWeight: "bold",
     color: "black",
-    marginBottom: MPT_SPACING_2,
     [upXsBreakpoint]: {
       fontSize: "0.85rem"
     },
     [upLgBreakpoint]: {
-      fontSize: "0.92rem"
+      fontSize: "1rem"
     },
     [upXlBreakpoint]: {
-      fontSize: "1rem"
+      fontSize: "1.12rem"
     }
   };
 

--- a/ngui/ui/src/utils/fonts.ts
+++ b/ngui/ui/src/utils/fonts.ts
@@ -1,5 +1,4 @@
 import { responsiveFontSizes } from "@mui/material/styles";
-import { MPT_SPACING_2 } from "./layouts";
 import { isEmpty as isEmptyObject } from "./objects";
 
 export const MAP_MARKER_FONT_SIZE_IN_PX = 11;


### PR DESCRIPTION
Single Resource Page updated

<img width="1251" alt="Screenshot" src="https://github.com/user-attachments/assets/258490e9-eac7-409e-9561-999628b31973" />
<img width="1252" alt="Screenshot 1" src="https://github.com/user-attachments/assets/2f7c2aef-5fe4-4523-a196-d71c05163889" />
<img width="1254" alt="Screenshot 2" src="https://github.com/user-attachments/assets/72cd5edb-cab8-42e4-b92b-5452cc3e4364" />
<img width="1508" alt="Screenshot 3" src="https://github.com/user-attachments/assets/85ad3494-2cc0-46ab-a7e5-6a74f877cb55" />
<img width="1501" alt="Screenshot 4" src="https://github.com/user-attachments/assets/37846902-e8a5-46e4-acb1-2c41730f9717" />


## Description

Changed single resource page styling. Added few Typography variants not to override already existing headers.

## Related issue number

MPT-5287

## Checklist

* [ ] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist
* [ ] New and existing unit tests pass locally