### PR TITLE
fix(MPT-8362): Refresh invitations after user accepts the invite

### DIFF
--- a/ngui/ui/src/pages/PendingInvitations/PendingInvitations.tsx
+++ b/ngui/ui/src/pages/PendingInvitations/PendingInvitations.tsx
@@ -74,6 +74,7 @@ const PendingInvitations = () => {
               styleProps={{ buttonsJustifyContent: "center" }}
               onSuccessAccept={() => {
                 refetchOrganizations();
+                refetchInvitations();
                 setProceedToNext(true);
               }}
               onSuccessDecline={() => {


### PR DESCRIPTION
Closes MPT-8362

## Description

#### Steps to Reproduce:

Invite a user to an organization.
As new user complete registration process and accept invitation.
Navigate to the Invitations Tab in Settings

#### Expected Result

There should be no pending invitations - FIXED

#### Actual Result

The invitation is still present. The user can accept or decline it again causing an error to be displayed - FIXED

## Related issue number

MPT-8362

## Checklist

* [ ] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist
* [ ] New and existing unit tests pass locally