### PR TITLE
fix: Fixing the 'undefined' auth header send to Apollo

### DIFF
--- a/ngui/server/api/baseClient.ts
+++ b/ngui/server/api/baseClient.ts
@@ -15,7 +15,9 @@ class BaseClient extends RESTDataSource {
   }
 
   override willSendRequest(_path: string, request: AugmentedRequest) {
-    request.headers["authorization"] = `Bearer ${this.token}`;
+    if (this.token && this.token !== "undefined") {
+      request.headers["authorization"] = `Bearer ${this.token}`;
+    }
   }
 }
 

--- a/ngui/ui/src/components/ApolloProvider/ApolloProvider.tsx
+++ b/ngui/ui/src/components/ApolloProvider/ApolloProvider.tsx
@@ -12,6 +12,9 @@ import { getEnvironmentVariable } from "utils/env";
 
 const httpBase = getEnvironmentVariable("VITE_APOLLO_HTTP_BASE");
 const wsBase = getEnvironmentVariable("VITE_APOLLO_WS_BASE");
+type OptScaleHeaders = {
+  "x-optscale-token"?: string;
+};
 
 const writeErrorToCache = (cache: DefaultContext, graphQLError: GraphQLError) => {
   const { extensions: { response: { url, body: { error } = {} } = {} } = {}, message } = graphQLError;
@@ -26,12 +29,15 @@ const ApolloClientProvider = ({ children }) => {
   const { token } = useGetToken();
 
   const signOut = useSignOut();
+  let headers: OptScaleHeaders = {};
+
+  if (token) {
+    headers["x-optscale-token"] = token;
+  }
 
   const httpLink = new HttpLink({
     uri: `${httpBase}/api`,
-    headers: {
-      "x-optscale-token": token
-    }
+    headers
   });
 
   const wsLink = new GraphQLWsLink(


### PR DESCRIPTION
Closes MPT-9565

## Description

Fix for the 'undefined' header sent to Apollo Server via string, and then forwarded to RestAPI.

## Related issue number

MPT-9565

## Checklist

* [ ] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist
* [ ] New and existing unit tests pass locally