### PR TITLE
feat: Add a script to render email templates using jinja2 or pystache

### DIFF
--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "scripts"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "jinja2>=3.1.6",
+    "pystache>=0.6.8",
+    "typer>=0.15.4",
+]

--- a/scripts/render_email_template.py
+++ b/scripts/render_email_template.py
@@ -1,0 +1,1592 @@
+from typing import Literal
+import rich
+from rich.syntax import Syntax
+import typer
+import pathlib
+import jinja2
+import pystache
+
+# NOTE: Copied from herald/send_templates.py
+
+PARAMETER_DUMPS = {
+    'alert': {
+        "email": ["kowalski@mail.mg"],
+        "subject": "OptScale Pool limit alert",
+        "template_type": "alert",
+        "template_params": {
+            "texts": {
+                "organization": {
+                    "name": "New York Central Park Zoo",
+                    "id": "c432cbd6-ab2b-4c6f-a601-c71c11b5502b",
+                    "currency_code": "$"
+                },
+                "pool_name": "Zoo-org",
+                "alert_type": "cost",
+                "threshold": "$5",
+            }
+        }
+    },
+    'employee_greetings': {
+        'email': ['andersonmatthew_hwp@hystax.com'],
+        'subject': 'Thank you for registering at FinOps for Cloud. Please proceed with the setup',
+        'template_type': 'employee_greetings',
+        'template_params': {
+            'texts': {
+                'name': 'andersonmatthew',
+                'token': 'MDAwZWxvY2F0aW9uIAowMDJlaWRlbnRpZmllciBhbmRlcnNvbm1hdHRoZXdfaHdwQGh5c3RheC5jb20KMDAyZGNpZCBlb'
+                         'WFpbDphbmRlcnNvbm1hdHRoZXdfaHdwQGh5c3RheC5jb20KMDAyMWNpZCBjcmVhdGVkOjE2MTcxOTg1MTMuNjk3MTIKMD'
+                         'AyZnNpZ25hdHVyZSB-fYhK5DixwPGK5RlnWa1TXEdUSuWLZ_XP9JUTn8jQogo',
+                'organization': {
+                    'id': 'd7092814-2b12-4e60-89c5-67919c9b17d6',
+                    'name': 'Funny company',
+                    'currency_code': '$'
+                }}}},
+    'invite': {
+        "email": ["me@1.com"],
+        "subject": "FinOps for Cloud invitation notification",
+        "template_type": "invite",
+        "template_params": {
+            "texts": {
+                "organization": {
+                    'id': "95a42273-2e87-4749-aa11-e60a61dcc0b8",
+                    'name': "ishorg",
+                    'currency_code': '$'
+                }
+            },
+            "links": {
+                "login_button": "https://172.22.20.8/login?email=me%401.ru&next=accept-invitation?inviteId=ffd31ed0"
+                                "-1886-4ed2-b7e6-2dfcbc7bb4d0 "
+            }
+        }
+    },
+    'new_cloud_account': {
+        "email": ["optscale-staging-notifications@hystax.com"],
+        "subject": "[172.22.20.8] Data source has been connected",
+        "template_type": "new_cloud_account",
+        "template_params": {
+            "texts": {
+                "cloud_account_id": "cb40fab5-3247-4064-b416-c3632786707a",
+                "cloud_account_name": "aws",
+                "cloud_account_type": "aws_cnr",
+                "organization": {
+                    'id': "a550ba8f-2766-4a4c-ba07-84a502ecca10",
+                    "name": "Twister Inc.",
+                    "currency_code": "$"
+                },
+                "user_email": "me2@1.com",
+                "user_name": "Mr Twister"
+            }
+        }
+    },
+    'cloud_account_deleted': {
+        "email": ["optscale-staging-notifications@hystax.com"],
+        "subject": "[172.22.20.8] Data source has been deleted",
+        "template_type": "cloud_account_deleted",
+        "template_params": {
+            "texts": {
+                "cloud_account_id": "cb40fab5-3247-4064-b416-c3632786707a",
+                "cloud_account_name": "aws",
+                "cloud_account_type": "aws_cnr",
+                "organization": {
+                    'id': "a550ba8f-2766-4a4c-ba07-84a502ecca10",
+                    "name": "Twister Inc.",
+                    "currency_code": "$"
+                },
+                "user_email": "me2@1.ru",
+                "user_name": "Mr Twister"
+            }
+        }
+    },
+    'organization_audit_submit': {
+        "email": ["optscale-staging-notifications@hystax.com"],
+        "subject": "[172.22.20.8] Organization submitted for technical audit",
+        "template_type": "organization_audit_submit",
+        "template_params": {
+            "texts": {
+
+                "organization": {
+                    "id": "a550ba8f-2766-4a4c-ba07-84a502ecca10",
+                    "name": "Twister Inc.",
+                    "currency_code": "$"
+                },
+                "employee": {
+                    "id": "cb40fab5-3247-4064-b416-c3632786707a",
+                    "name": "Twister Inc."
+                }
+            }
+        }
+    },
+    'new_employee': {
+        "email": ["optscale-staging-notifications@hystax.com"],
+        "subject": "[172.22.20.8] New user joined organization",
+        "template_type": "new_employee",
+        "reply_to_email": "me2@1.com",
+        "template_params": {
+            "texts": {
+                "organization": {
+                    "id": "a550ba8f-2766-4a4c-ba07-84a502ecca10",
+                    "name": "Twister Inc.",
+                    "currency_code": "$"
+                },
+                "user": {
+                    "id": "63b4c37e-ce9b-47fb-be38-413a23168ae3",
+                    "email": "me2@1.com",
+                    "authentication_type": "password"
+                },
+                "users_count": 2,
+            }
+        }
+    },
+    'new_subscriber': {
+        "email": ["optscale-staging-notifications@hystax.com"],
+        "subject": "[172.22.20.8] New live demo subscriber",
+        "template_type": "new_subscriber",
+        "reply_to_email": "me2@1.com",
+        "template_params": {
+            "texts": {
+                "user": {
+                    "email": "me2@1.com",
+                    "subscribe": True
+                },
+            }
+        }
+    },
+    'pool_exceed_report': {
+        'email': ['james31_pza@hystax.com'],
+        'subject': 'Action Required: SoftwareOne FinOps for Cloud Pool Limit Exceed Alert',
+        'template_type': 'pool_exceed_report',
+        'template_params': {
+            'texts': {
+                'total_forecast': 293.5,
+                'exceeded': [
+                    {
+                        'forecast': 293.5,
+                        'id': '950251a8-49e4-4f06-a93e-ee4faed97701',
+                        'limit': 50,
+                        'pool_name': 'AQA_1617018508.3637385. It is very very very very very very very very very '
+                                       'very very very very very very very long name',
+                        'total_expenses': 293.5
+                    },
+                    {
+                        'forecast': 293.5,
+                        'id': '9e07786f-c476-484e-adc5-43d76815bd1d',
+                        'limit': 100,
+                        'pool_name': 'AQA_CA_1617018508.3637757_find_report',
+                        'total_expenses': 293.5
+                    }
+                ],
+                'organization': {
+                    'id': '6946211f-47ff-43a3-a9a3-3e5f57d52415',
+                    'name': 'AQA_1617018508.3637385',
+                    'currency_code': '$'
+                }
+            }
+        }
+    },
+    'pool_exceed_resources_report': {
+        'email': ['ranxygcrfg@novaemail.com'],
+        'subject': 'Action Required: SoftwareOne FinOps for Cloud Pool Limit Exceed Alert',
+        'template_type': 'pool_exceed_resources_report',
+        'template_params': {
+            'texts': {
+                'exceeded_pools_count': 2,
+                'exceeded_pool_forecasts_count': 2,
+                "exceeded_pool_forecasts": [
+                    {
+                        'forecast': 448.72,
+                        'limit': 100,
+                        'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                        'pool_name': 'Dalek Industry pool',
+                        'pool_purpose': 'business_unit',
+                        'total_expenses': 448.72,
+                        "resources": [
+                            {
+                                'active': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-2'
+                                                      '#InstanceDetails:instanceId=i-082b1a163698b8ede',
+                                'cloud_created_at': 1607326764,
+                                'cloud_resource_id': 'i-082b1a163698b8ede',
+                                'flavor': 't2.large',
+                                'image_id': 'ami-09d7e4ccf2c68700d',
+                                'last_seen': 1617152478,
+                                'last_seen_not_stopped': 1617152478,
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'name': 'HystaxWebSite. It is very very very very very very very very very very very '
+                                        'very very very very very long name',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-2',
+                                'resource_id': 'd3809841-eb70-4568-bb02-e962e401fdca',
+                                'spotted': False,
+                                'stopped_allocated': False,
+                                'type': 'instance',
+                                'security_groups': [
+                                    {
+                                        'GroupId': 'sg-0d99e8ecd70254ebe',
+                                        'GroupName': 'websites'}],
+                                'tags': {
+                                    'aws:createdBy': 'IAMUser:AIDA4YBYU3OICYSASYZ2E:pkozlov'
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        'forecast': 448.72,
+                        'limit': 100,
+                        'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                        'pool_name': 'My Pool',
+                        'pool_purpose': 'business_unit',
+                        'total_expenses': 448.72,
+                        "resources": [
+                            {
+                                'active': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-2'
+                                                      '#InstanceDetails:instanceId=i-082b1a163698b8ede',
+                                'cloud_created_at': 1607326764,
+                                'cloud_resource_id': 'i-082b1a163698b8ede',
+                                'flavor': 't2.large',
+                                'image_id': 'ami-09d7e4ccf2c68700d',
+                                'last_seen': 1617152478,
+                                'last_seen_not_stopped': 1617152478,
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'name': 'HystaxWebSite. It is very very very very very very very very very very very '
+                                        'very very very very very long name',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-2',
+                                'resource_id': 'd3809841-eb70-4568-bb02-e962e401fdca',
+                                'spotted': False,
+                                'stopped_allocated': False,
+                                'type': 'instance',
+                                'security_groups': [
+                                    {
+                                        'GroupId': 'sg-0d99e8ecd70254ebe',
+                                        'GroupName': 'websites'}],
+                                'tags': {
+                                    'aws:createdBy': 'IAMUser:AIDA4YBYU3OICYSASYZ2E:pkozlov'
+                                }
+                            }
+                        ]
+                    }
+                ],
+                'exceeded_pools': [
+                    {
+                        'forecast': 448.72,
+                        'limit': 100,
+                        'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                        'pool_name': 'My pool',
+                        'pool_purpose': 'business_unit',
+                        'total_expenses': 448.72,
+                        "resources": [
+                            {
+                                'active': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-2'
+                                                      '#InstanceDetails:instanceId=i-082b1a163698b8ede',
+                                'cloud_created_at': 1607326764,
+                                'cloud_resource_id': 'i-082b1a163698b8ede',
+                                'flavor': 't2.large',
+                                'image_id': 'ami-09d7e4ccf2c68700d',
+                                'last_seen': 1617152478,
+                                'last_seen_not_stopped': 1617152478,
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'name': 'HystaxWebSite. It is very very very very very very very very very very very '
+                                        'very very very very very long name',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-2',
+                                'resource_id': 'd3809841-eb70-4568-bb02-e962e401fdca',
+                                'spotted': False,
+                                'stopped_allocated': False,
+                                'type': 'instance',
+                                'security_groups': [
+                                    {
+                                        'GroupId': 'sg-0d99e8ecd70254ebe',
+                                        'GroupName': 'websites'}],
+                                'tags': {
+                                    'aws:createdBy': 'IAMUser:AIDA4YBYU3OICYSASYZ2E:pkozlov'
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        'forecast': 448.72,
+                        'limit': 100,
+                        'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                        'pool_name': 'Dalek Industry pool',
+                        'pool_purpose': 'business_unit',
+                        'total_expenses': 448.72,
+                        'resources': [
+                            {
+                                'active': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-2'
+                                                      '#InstanceDetails:instanceId=i-082b1a163698b8ede',
+                                'cloud_created_at': 1607326764,
+                                'cloud_resource_id': 'i-082b1a163698b8ede',
+                                'flavor': 't2.large',
+                                'image_id': 'ami-09d7e4ccf2c68700d',
+                                'last_seen': 1617152478,
+                                'last_seen_not_stopped': 1617152478,
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'name': 'HystaxWebSite. It is very very very very very very very very very very very '
+                                        'very very very very very long name',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-2',
+                                'resource_id': 'd3809841-eb70-4568-bb02-e962e401fdca',
+                                'spotted': False,
+                                'stopped_allocated': False,
+                                'type': 'instance',
+                                'security_groups': [
+                                    {
+                                        'GroupId': 'sg-0d99e8ecd70254ebe',
+                                        'GroupName': 'websites'}],
+                                'tags': {
+                                    'aws:createdBy': 'IAMUser:AIDA4YBYU3OICYSASYZ2E:pkozlov'}},
+                            {
+                                'active': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-2'
+                                                      '#InstanceDetails:instanceId=i-00360dfdf85958d24',
+                                'cloud_created_at': 1607326819,
+                                'cloud_resource_id': 'i-00360dfdf85958d24',
+                                'flavor': 't2.large',
+                                'image_id': 'ami-057935eae1159db28',
+                                'last_seen': 1617152478,
+                                'last_seen_not_stopped': 1617152478,
+                                'name': 'OptScaleWebSite',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-2',
+                                'resource_id': '56c9b581-20cd-41b6-af1d-be37c4c8cf64',
+                                'spotted': False,
+                                'stopped_allocated': False,
+                                'type': 'instance',
+                                'security_groups': [
+                                    {
+                                        'GroupId': 'sg-0d99e8ecd70254ebe',
+                                        'GroupName': 'websites'}],
+                                'tags': {
+                                    'aws:createdBy': 'IAMUser:AIDA4YBYU3OICYSASYZ2E:pkozlov'}},
+                            {
+                                'active': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-2'
+                                                      '#InstanceDetails:instanceId=i-0e464cfbf9650bd21',
+                                'cloud_created_at': 1607339156,
+                                'cloud_resource_id': 'i-0e464cfbf9650bd21',
+                                'flavor': 't2.large',
+                                'image_id': 'ami-0896ae01b544f65a8',
+                                'last_seen': 1617152478,
+                                'last_seen_not_stopped': 1617152478,
+                                'name': 'finops-practice',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-2',
+                                'resource_id': '422e7381-56cd-4d67-a8e8-2429691536f1',
+                                'spotted': False,
+                                'stopped_allocated': False,
+                                'type': 'instance',
+                                'security_groups': [
+                                    {
+                                        'GroupId': 'sg-0d99e8ecd70254ebe',
+                                        'GroupName': 'websites'}],
+                                'tags': {
+                                    'aws:createdBy': 'IAMUser:AIDA4YBYU3OICYSASYZ2E:pkozlov'}},
+                            {
+                                'active': True,
+                                'attached': False,
+                                'cloud_account_id': 'ba5a7439-df3a-4d41-9244-4927b80770f2',
+                                'cloud_account_name': 'AWS',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=eu-central-1'
+                                                      '#Volumes:volumeId=vol-01b510489d2a9cd00',
+                                'cloud_resource_id': 'vol-01b510489d2a9cd00',
+                                'last_attached': 0,
+                                'last_seen': 1617152217,
+                                'name': 'ish-ami-deletion-test-volume',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'eu-central-1',
+                                'resource_id': '2a003a1f-0e66-4bc6-8d38-7036b15720a6',
+                                'size': 1,
+                                'snapshot_id': None,
+                                'type': 'volume',
+                                'volume_type': 'gp2',
+                                'tags': {
+                                    'aws:createdBy': 'Root:044478323321'}},
+                            {
+                                'active': True,
+                                'attached': False,
+                                'cloud_account_id': 'ba5a7439-df3a-4d41-9244-4927b80770f2',
+                                'cloud_account_name': 'AWS',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=eu-central-1'
+                                                      '#Volumes:volumeId=vol-0753b8ad653355bda',
+                                'cloud_resource_id': 'vol-0753b8ad653355bda',
+                                'last_attached': 1609330672,
+                                'last_seen': 1617152217,
+                                'name': 'ubuntu-ducky_15ad46bc-1b5c-b22d-9cd1-928241c509c5',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'eu-central-1',
+                                'resource_id': 'afdfc60f-0b2b-4bc6-aa5b-c9f74470bbe5',
+                                'size': 5,
+                                'snapshot_id': None,
+                                'type': 'volume',
+                                'volume_type': 'gp2',
+                                'tags': {
+                                    'aws:createdBy': 'IAMUser:AIDAJGWH6JNRGDXONCBLI:va-iam-full',
+                                    'hystax_backup_id': '53310f74-00be-4696-b752-8b30155e90fe',
+                                    'hystax_device_id': '8bee6539-8260-8f59-cd9b-f2c3b9a87a44',
+                                    'hystax_device_name': 'ubuntu-ducky',
+                                    'hystax_type': 'acura'}},
+                            {
+                                'active': True,
+                                'attached': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-2'
+                                                      '#Volumes:volumeId=vol-01ddb07d1f7d3eaa1',
+                                'cloud_resource_id': 'vol-01ddb07d1f7d3eaa1',
+                                'last_attached': 1617152218,
+                                'last_seen': 1617152217,
+                                'name': '',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-2',
+                                'resource_id': 'ce72bdc8-eb36-43e9-8288-d3ea50077fc7',
+                                'size': 30,
+                                'snapshot_id': 'snap-0bb2b0d4627a9ea92',
+                                'type': 'volume',
+                                'volume_type': 'gp3',
+                                'tags': {}},
+                            {
+                                'active': True,
+                                'attached': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-2'
+                                                      '#Volumes:volumeId=vol-0d2a2bc4145146934',
+                                'cloud_resource_id': 'vol-0d2a2bc4145146934',
+                                'last_attached': 1617152218,
+                                'last_seen': 1617152217,
+                                'name': '',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-2',
+                                'resource_id': 'df705cae-5e13-47da-b1a8-fddde6a2b037',
+                                'size': 40,
+                                'snapshot_id': 'snap-0e2213980002234ef',
+                                'volume_type': 'gp3',
+                                'type': 'volume',
+                                'tags': {}},
+                            {
+                                'active': True,
+                                'attached': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-2'
+                                                      '#Volumes:volumeId=vol-0b1884d70bf748195',
+                                'cloud_resource_id': 'vol-0b1884d70bf748195',
+                                'last_attached': 1617152218,
+                                'last_seen': 1617152217,
+                                'name': '',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-2',
+                                'resource_id': 'f905da3a-ef30-4c57-bb62-f34b0f140fd9',
+                                'size': 30,
+                                'snapshot_id': 'snap-0282131236002be43',
+                                'volume_type': 'gp3',
+                                'type': 'volume',
+                                'tags': {}},
+                            {
+                                'active': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-1'
+                                                      '#Snapshots:snapshotId=snap-03dc9f67588b2f3d0',
+                                'cloud_resource_id': 'snap-03dc9f67588b2f3d0',
+                                'description': 'Created by CreateImage(i-0c041db9f5b6ccbef) for ami-000060dc272d8ed47 '
+                                               'from vol-0a12e44b17a7d0d93',
+                                'last_seen': 1617152176,
+                                'name': '',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-1',
+                                'resource_id': '009c7c48-94bf-44e7-9000-9801db3a37c3',
+                                'size': 30,
+                                'state': 'completed',
+                                'type': 'snapshot',
+                                'volume_id': 'vol-0a12e44b17a7d0d93',
+                                'tags': {}},
+                            {
+                                'active': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-1'
+                                                      '#Snapshots:snapshotId=snap-012a9084f4db84efe',
+                                'cloud_resource_id': 'snap-012a9084f4db84efe',
+                                'description': 'Created by CreateImage(i-0c041db9f5b6ccbef) for ami-05a0b94d614da51d8 '
+                                               'from vol-0a12e44b17a7d0d93',
+                                'name': '',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-1',
+                                'resource_id': 'e68ddee4-7e2a-42ee-a21a-5999e0cc3fee', 'last_seen': 1617152176,
+                                'size': 30,
+                                'state': 'completed',
+                                'type': 'snapshot',
+                                'volume_id': 'vol-0a12e44b17a7d0d93',
+                                'tags': {}},
+                            {
+                                'active': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-1'
+                                                      '#Snapshots:snapshotId=snap-0b060b59614baee12',
+                                'cloud_resource_id': 'snap-0b060b59614baee12',
+                                'description': 'Created by CreateImage(i-0ffa47c24ddbfaedf) for ami-01c997d55fdff26b8 '
+                                               'from vol-0dcec72ac83abcb10',
+                                'last_seen': 1617152176,
+                                'name': '',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-1',
+                                'resource_id': '9d311563-54c0-4f24-89b6-2bf08b9fcf98',
+                                'size': 40,
+                                'state': 'completed',
+                                'type': 'snapshot',
+                                'volume_id': 'vol-0dcec72ac83abcb10',
+                                'tags': {}},
+                            {
+                                'active': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-2'
+                                                      '#Snapshots:snapshotId=snap-0bb2b0d4627a9ea92',
+                                'cloud_resource_id': 'snap-0bb2b0d4627a9ea92',
+                                'description': 'Copied for DestinationAmi ami-0896ae01b544f65a8 from SourceAmi '
+                                               'ami-000060dc272d8ed47 for SourceSnapshot snap-03dc9f67588b2f3d0. Task '
+                                               'created on 1,607,338,338,349.',
+                                'last_seen': 1617152176,
+                                'name': '',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-2',
+                                'resource_id': '707948fc-571b-4e05-8ac1-3c54d7fe328f',
+                                'size': 30,
+                                'state': 'completed',
+                                'type': 'snapshot',
+                                'volume_id': None,
+                                'tags': {}},
+                            {
+                                'active': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-2'
+                                                      '#Snapshots:snapshotId=snap-0e2213980002234ef',
+                                'cloud_resource_id': 'snap-0e2213980002234ef',
+                                'description': 'Copied for DestinationAmi ami-09d7e4ccf2c68700d from SourceAmi '
+                                               'ami-01c997d55fdff26b8 for SourceSnapshot snap-0b060b59614baee12. Task '
+                                               'created on 1,607,325,344,215.',
+                                'last_seen': 1617152176,
+                                'name': '',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-2',
+                                'resource_id': '87160f24-ef1f-4495-8489-16b668ad39cc',
+                                'size': 40,
+                                'state': 'completed',
+                                'volume_id': None,
+                                'type': 'snapshot',
+                                'tags': {}},
+                            {
+                                'active': True,
+                                'cloud_account_id': '5c1ed35a-bf6b-4c7d-897a-8388b220fff3',
+                                'cloud_account_name': 'AWS linked',
+                                'cloud_console_link': 'https://console.aws.amazon.com/ec2/v2/home?region=us-west-2'
+                                                      '#Snapshots:snapshotId=snap-0282131236002be43',
+                                'cloud_resource_id': 'snap-0282131236002be43',
+                                'description': 'Copied for DestinationAmi ami-057935eae1159db28 from SourceAmi '
+                                               'ami-05a0b94d614da51d8 for SourceSnapshot snap-012a9084f4db84efe. Task '
+                                               'created on 1,607,325,351,739.',
+                                'last_seen': 1617152176,
+                                'name': '',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'us-west-2',
+                                'resource_id': 'bead6bad-b296-4fe4-92de-fc37a89e93b1',
+                                'size': 30,
+                                'state': 'completed',
+                                'type': 'snapshot',
+                                'volume_id': None,
+                                'tags': {}},
+                            {
+                                'active': True,
+                                'cloud_account_id': 'ba5a7439-df3a-4d41-9244-4927b80770f2',
+                                'cloud_account_name': 'AWS',
+                                'cloud_console_link': 'https://console.aws.amazon.com/s3/buckets/cf-templates'
+                                                      '-nvn8cifbt6g5-eu-north-1?region=eu-north-1&tab=objects',
+                                'cloud_resource_id': 'cf-templates-nvn8cifbt6g5-eu-north-1',
+                                'last_seen': 1617152439,
+                                'name': 'cf-templates-nvn8cifbt6g5-eu-north-1',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'eu-north-1',
+                                'resource_id': 'a1b4ef44-1ef2-4123-bb66-f78d48a39ad7',
+                                'type': 'bucket',
+                                'tags': {}},
+                            {
+                                'active': True,
+                                'cloud_account_id': 'ba5a7439-df3a-4d41-9244-4927b80770f2',
+                                'cloud_account_name': 'AWS',
+                                'cloud_console_link': 'https://console.aws.amazon.com/s3/buckets/202101060-liberty'
+                                                      '-backup?region=eu-central-1&tab=objects',
+                                'cloud_resource_id': '202101060-liberty-backup',
+                                'last_seen': 1617152439,
+                                'name': '202101060-liberty-backup',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'eu-central-1',
+                                'resource_id': '949bada8-92ae-4871-8faa-342b95d2f28c',
+                                'type': 'bucket',
+                                'tags': {
+                                    'aws:createdBy': 'IAMUser:AIDAJGWH6JNRGDXONCBLI:va-iam-full'}},
+                            {
+                                'active': True,
+                                'cloud_account_id': 'ba5a7439-df3a-4d41-9244-4927b80770f2',
+                                'cloud_account_name': 'AWS',
+                                'cloud_console_link': 'https://console.aws.amazon.com/s3/buckets/hystax-eu-west-1'
+                                                      '?region=eu-west-1&tab=objects',
+                                'cloud_resource_id': 'hystax-eu-west-1',
+                                'last_seen': 1617152439,
+                                'name': 'hystax-eu-west-1',
+                                'organization_id': '955f3783-ad70-4ad8-9682-b64890ef95c6',
+                                'owner_id': '0b2287ea-c543-4b47-a8aa-a2953fad9eb4',
+                                'owner_name': 'Tester',
+                                'pool_id': '6e4c3ef9-37a9-47ec-87f7-0a864af86016',
+                                'pool_name': 'Dalek Industry',
+                                'pool_purpose': 'business_unit',
+                                'region': 'eu-west-1',
+                                'resource_id': '0fee4514-7b48-4616-9cd1-1b88cdbf5eef',
+                                'type': 'bucket',
+                                'tags': {
+                                    'aws:createdBy': 'IAMUser:AIDAIPPYCHRYQONGDLRJS:pk-full'}
+                            }
+                        ]
+                    }
+                ],
+                'organization': {
+                    'id': 'c2272558-912f-4571-8dc5-99bd5d30f7d1',
+                    'name': 'Dalek Industry',
+                    'currency_code': '$'
+                },
+            }
+        }
+    },
+    'pool_owner_violation_report': {
+        'email': ['lori54_lskqtdln@hystax.com'],
+        'subject': 'Action required: SoftwareOne FinOps for Cloud Resource Constraints Report',
+        'template_type': 'pool_owner_violation_report',
+        'template_params': {
+            'texts': {
+                'total_differ': 0,
+                'total_violated': 2,
+                'differ_resources': [],
+                'organization': {
+                    'id': '28eef4b1-4acf-4050-b833-86c3b2aaf1e7',
+                    'name': 'Lori Inc'
+                },
+                'violated_resources': [
+                    {
+                        'cloud_resource_id': 'i-05377b0fa5b9674fd',
+                        'constraint_limit': 1,
+                        'created_at': 1617198128,
+                        'deleted_at': 0,
+                        'hit_value': 9,
+                        'id': '026df797-2d92-45d6-9f8e-6be329e346e0',
+                        'organization_id': '28eef4b1-4acf-4050-b833-86c3b2aaf1e7',
+                        'owner_id': '25252003-7c90-47df-a942-e8a6caaa58fb',
+                        'owner_name': 'tparker',
+                        'pool_id': 'eceb67e8-da0e-40ff-b9c6-9f0b23090135',
+                        'pool_name': 'AQA_1617196474.73338',
+                        'pool_purpose': 'business_unit',
+                        'resource_id': '08589dbe-3291-4a8d-8e52-7302933a46ee',
+                        'resource_type': 'Instance',
+                        'resource_name': 'aqa_eu_instance_for_migration. It is very very very very very very very '
+                                         'very very very very very very very very very long name',
+                        'time': 1617198128,
+                        'type': 'expense_limit'},
+                    {
+                        'constraint_limit': 1,
+                        'created_at': 1617198124,
+                        'deleted_at': 0,
+                        'hit_value': 733,
+                        'id': '650cbb4d-7b87-4153-bd21-ca636168a59f',
+                        'organization_id': '28eef4b1-4acf-4050-b833-86c3b2aaf1e7',
+                        'owner_id': '25252003-7c90-47df-a942-e8a6caaa58fb',
+                        'owner_name': 'tparker',
+                        'pool_id': 'eceb67e8-da0e-40ff-b9c6-9f0b23090135',
+                        'pool_name': 'AQA_1617196474.73338',
+                        'pool_purpose': 'business_unit',
+                        'cloud_resource_id': 'i-05377b0fa5b9674fd',
+                        'resource_id': '08589dbe-3291-4a8d-8e52-7302933a46ee',
+                        'resource_name': 'aqa_eu_instance_for_migration',
+                        'resource_type': 'Instance',
+                        'time': 1617198124,
+                        'type': 'ttl'}]}}},
+    'resource_owner_violation_alert': {
+        "email": ["kepler71@de.io"],
+        "template_type": "resource_owner_violation_alert",
+        "subject": "Action required: SoftwareOne FinOps for Cloud Resource Constraint Violation Alert",
+        "template_params": {
+            "texts": {
+                "total_violated": 2,
+                "organization": {
+                    "id": "2254d0c7-d341-45cd-a2b4-200f8df8112a",
+                    "name": "Renaissance science",
+                    "currency_code": "$"
+                },
+                "violated_resources": [
+                    {
+                        "cloud_resource_id": "hystax-eu-fra",
+                        "employee_id": "99ba5718-c73d-4cf2-84f7-62cc7df6c020",
+                        "employee_name": "Iogann Kepler",
+                        "hit_value": 1617706815,
+                        "pool_id": "3f575a6a-237d-4f4d-a4b4-1f8005451432",
+                        "pool_name": "IK_ORG",
+                        "resource_name": "hystax-eu-fra. It is very very very very very very very very very very very "
+                                         "very very very very very long name",
+                        "type": "ttl",
+                        "resource_id": "e2b0412d-d3d3-425e-bd1e-e27ac881d58e",
+                    },
+                    {
+                        "cloud_resource_id": "hystax-eu-fra",
+                        "employee_id": "99ba5718-c73d-4cf2-84f7-62cc7df6c020",
+                        "employee_name": "Iogann Kepler",
+                        "hit_value": 20,
+                        "pool_id": "3f575a6a-237d-4f4d-a4b4-1f8005451432",
+                        "pool_name": "IK_ORG",
+                        "resource_name": "hystax-eu-fra",
+                        "type": "expense_limit",
+                        "resource_id": "2b2dd58e-366d-4138-ad72-756aec545eca",
+                    }
+                ]
+            }
+        }
+    },
+    'resource_owner_violation_report': {
+        "email": ["root@hystax.com"],
+        "template_type": "resource_owner_violation_report",
+        "subject": "Action required: SoftwareOne FinOps for Cloud Resource Constraints Report",
+        "template_params": {
+            "texts": {
+                "total_differ": 1,
+                "total_violated": 1,
+                "differ_resources": [{
+                    "cloud_resource_id": "hystax-eu-fra",
+                    "created_at": 1608790595,
+                    "deleted_at": 0,
+                    "id": "d48a8c38-19ea-4ae5-9229-c46887508480",
+                    "limit": 1,
+                    "organization_id": "b8835bce-da4c-4c29-98a0-4b4967baba53",
+                    "owner_id": "ecded3e5-d84f-4354-bce2-db2c89755e6c",
+                    "owner_name": "Ivan Shashero",
+                    "pool_id": "5e3390d7-76ea-4c3b-a00a-b3bbc733a115",
+                    "pool_name": "test",
+                    "pool_purpose": "pool",
+                    "resource_id": "4532cba1-e5cf-4785-a4ee-67c08c5440cf",
+                    "resource_name": "hystax-eu-fra. It is very very very very very very very very very very very "
+                                     "very very very very very long name",
+                    "resource_type": "Bucket",
+                    "type": "ttl",
+                    "policy": {
+                        "active": True,
+                        "created_at": 1608790627,
+                        "deleted_at": 0,
+                        "id": "bba410ce-d23b-4dfd-8331-422270984cdb",
+                        "limit": 2,
+                        "organization_id": "b8835bce-da4c-4c29-98a0-4b4967baba53",
+                        "pool_id": "5e3390d7-76ea-4c3b-a00a-b3bbc733a115",
+                        "pool_name": "test",
+                        "type": "ttl"
+                    },
+                }],
+                "organization": {
+                    "id": "b8835bce-da4c-4c29-98a0-4b4967baba53",
+                    "name": "Czar Pictures"
+                },
+                "violated_resources": [{
+                    "cloud_resource_id": "hystax-eu-fra",
+                    "constraint_limit": 1,
+                    "created_at": 1617025349,
+                    "deleted_at": 0,
+                    "hit_value": 10903,
+                    "id": "cb292ab1-6be8-46f5-8694-f94c0b0a2edf",
+                    "organization_id": "b8835bce-da4c-4c29-98a0-4b4967baba53",
+                    "owner_id": "ecded3e5-d84f-4354-bce2-db2c89755e6c",
+                    "owner_name": "Ivan Shashero",
+                    "pool_id": "5e3390d7-76ea-4c3b-a00a-b3bbc733a115",
+                    "pool_name": "test",
+                    "pool_purpose": "pool",
+                    "resource_id": "4532cba1-e5cf-4785-a4ee-67c08c5440cf",
+                    "resource_name": "hystax-eu-fra. It is very very very very very very very very very very very "
+                                     "very very very very very long name",
+                    "resource_type": "Bucket",
+                    "time": 1617025349,
+                    "type": "ttl"
+                }]
+            }
+        }
+    },
+    'weekly_expense_report': {
+        "email": ["root@hystax.com"],
+        "template_type": "weekly_expense_report",
+        "subject": "FinOps for Cloud weekly expense report",
+        "template_params": {
+            "texts": {
+                "organization": {
+                    "forecast": 482.32,
+                    "id": "ed74eb3b-1c4d-477e-b431-28f697d62233",
+                    "limit": 500,
+                    "name": "ishorg",
+                    "total_cost": 451.21,
+                    "currency_code": "$"
+                },
+                "pools": [
+                    {
+                        "cost": 0,
+                        "forecast": 0.0,
+                        "id": "b1d60c69-4e14-4bda-be16-dc8fc6d8b941",
+                        "limit": 0,
+                        "name": "123. It is very very very very very very very very very very very very very very "
+                                "very very long name",
+                        "tracked": 0,
+                    },
+                    {
+                        "cost": 6.41,
+                        "forecast": 6.85,
+                        "id": "f5a563ee-b38e-4fff-8277-41bf32b8725c",
+                        "limit": 5,
+                        "name": "trash",
+                        "tracked": 15
+                    },
+                    {
+                        "limit": 500,
+                        "cost": 49.27,
+                        "forecast": 52.67,
+                        "id": "a575532e-3abb-4d5b-b4d1-c3c65c5166ed",
+                        "name": "ishorg",
+                        "tracked": 106
+                    },
+                    {
+                        "cost": 91.67,
+                        "forecast": 97.99,
+                        "id": "5e3390d7-76ea-4c3b-a00a-b3bbc733a115",
+                        "limit": 100,
+                        "name": "test",
+                        "tracked": 1
+                    },
+                    {
+                        "cost": 93.56,
+                        "forecast": 122222312300.01,
+                        "id": "278c5876-43bb-4f33-9dff-55ae518d65db",
+                        "limit": 50,
+                        "name": "testo",
+                        "tracked": 2
+                    }
+                ],
+                "unassigned": {
+                    "forecast": 224.81,
+                    "total_cost": 210.3,
+                    "resources_tracked": 540
+                }
+            }
+        }
+    },
+    'bumi_task_execution_failed': {
+        'email': 'test_user@service.com',
+        'subject': '[127.0.0.1] Bumi task execution failed',
+        'template_type': 'bumi_task_execution_failed',
+        'template_params': {
+            'texts': {
+                'organization': {
+                    'id': '6946211f-47ff-43a3-a9a3-3e5f57d52415',
+                    'name': 'Czar Pictures'
+                },
+                "reason": "Timeout error while process task 1639638582 (organization_id b74f3ca6-c392-4bcb-96b3-2ffaa0281810)",
+                'failed_modules': [{
+                    'module': 'instance_migration',
+                    'error': 'Timeout error while process task 1639638582 '
+                             '(organization_id b74f3ca6-c392-4bcb-96b3-2ffaa0281810, '
+                             'module instance_migration, try 0) step Process'
+                }]
+            }}},
+    'bumi_module_execution_failed': {
+        'email': 'test_user@service.com',
+        'subject': '[127.0.0.1] Recommendation module failed',
+        'template_type': 'bumi_module_execution_failed',
+        'template_params': {
+            'texts': {
+                'organization': {
+                    'id': 'b8835bce-da4c-4c29-98a0-4b4967baba53',
+                    'name': 'Czar Pictures'
+                },
+                'failed_modules': [{
+                    'module': 'short_living_instances',
+                    'error': "name 'LOG' is not defined"}]
+            }}},
+    'first_shareable_resources': {
+        "email": ["azaza@ma.il"],
+        "subject": "FinOps for Cloud shared environments notification",
+        "template_type": "first_shareable_resources",
+        "template_params": {
+            "texts": {
+                "organization": {
+                    "id": "5d3d4501-0de8-40dc-a9ed-df2fb1396141",
+                    "name": "am2"
+                }
+            },
+        }
+    },
+    'report_import_failed': {
+        'email': ['azaza@ma.il'],
+        'subject': '[1.2.3.4] Report import failed',
+        'template_type': 'report_import_failed',
+        'template_params': {
+            "texts": {
+                'organization': {
+                    'id': '5d3d4501-0de8-40dc-a9ed-df2fb1396141',
+                    'name': 'am2'
+                },
+                'cloud_account': {
+                    'id': '8aa14efd-d111-4934-9c19-92b6f0da18fe',
+                    'name': 'Ali',
+                    'type': 'alibaba_cnr',
+                    'last_import_at': '09/03/2021 10:37:57 UTC'
+                },
+                'reason': 'Because'
+            },
+        }
+    },
+    'environment_changes': {
+        "email": ["azaza@ma.il"],
+        "subject": "Environment changed",
+        "template_type": "environment_changes",
+        "template_params": {
+            "texts": {
+                "organization": {
+                    "name": "AS_Test_ORG",
+                    "id": "7e23e036-87b9-460f-aa3e-10f2a5b63f54",
+                    "currency_code": "$"
+                },
+                "user": {
+                    "user_display_name": "ASBalmah_Engineer"
+                },
+                "environment_status_changed": {
+                    "changed_environment": {
+                        "name": "Test_Environment",
+                        "id": "5dba5d14-d385-4b29-a426-b37160d1adbf",
+                        "status": "released"
+                    }
+                },
+                "environment_prop_changed": {
+                    "changed_environment": {
+                        "property_info": [
+                            {
+                                "name": "Purpose",
+                                "previous_value": "Staging",
+                                "new_value": "Production"
+                            },
+                            {
+                                "name": "Purpose2",
+                                "previous_value": "Staging2",
+                                "new_value": "Production2"
+                            }
+                        ],
+                        "name": "Test_Environment",
+                        "id": "5dba5d14-d385-4b29-a426-b37160d1adbf",
+                    }
+                },
+                "environments_infos": {
+                    "cloud_resource_id": "environment_f09696910bdd874a99cd74c8f05b5c44",
+                    "resource_name": "Test_Environment",
+                    "cloud_account_id": "07b66570-ad21-4cae-93f7-b079b548daae",
+                    "cloud_account_name": "Environment",
+                    "type": "Test_Type",
+                    "resource_id": "5dba5d14-d385-4b29-a426-b37160d1adbf",
+                    "pool": "Environment",
+                    "resource_type": "environment",
+                    "jira_tickets": [
+                        {
+                            "url": "https://jira.com.example/NGUI-1242",
+                            "name": "NGUI-1242"
+                        }, 
+                        {
+                            "url": "https://jira.com.example/NGUI-3214",
+                            "name": "NGUI-3214"
+                        }
+                    ],
+                    "software": "software_example",
+                    "status": {
+                        "Status": "IN USE",
+                        "details": {
+                            "User": "John Doe",
+                            "Since": "2024-08-01 06:44:49 UTC",
+                            "Until": "2024-08-01 10:00:00 UTC",
+                            "Remained": "3 hours"
+                        }
+                    },
+                    "upcoming_bookings": [
+                        {
+                            "details": {
+                                "User": "John Doe",
+                                "Since": "2024-08-02 07:00:00 UTC",
+                                "Until": "2024-08-04 07:00:00 UTC",
+                                "Duration": "48 hours"
+                            },
+                            "status_info": {
+                                "Status": "<upcoming booking status>"
+                            }
+                        }
+                    ],
+                    "contains_envs": True,
+                    "env_properties": [
+                        {
+                            "env_key": "Purpose",
+                            "env_value": "Production"
+                        },
+                        {
+                            "env_key": "Software version",
+                            "env_value": "v1.2.32141"
+                        }
+
+                    ]
+                },
+                "environment_state_changed": {
+                    "changed_environment": {
+                        "name": "Test_Environment",
+                        "id": "5dba5d14-d385-4b29-a426-b37160d1adbf",
+                        "previous_value": "Active",
+                        "new_value": "Not Active",
+                    }
+                },
+                "name": "John Doe",
+            },
+        }
+    },
+    'anomaly_detection_alert': {
+        'email': ['james31_pza@hystax.com'],
+        'subject': 'Anomaly detected',
+        'template_type': 'anomaly_detection_alert',
+        'template_params': {
+            'texts': {
+                'title': 'Anomaly detection Alert',
+                'organization': {
+                    'id': '6946211f-47ff-43a3-a9a3-3e5f57d52415',
+                    'name': 'AQA_1617018508.3637385',
+                    'currency_code': '$'
+                },
+                'organization_constraint': {
+                    'name': 'Anomaly#1',
+                    'resource_count_anomaly': False,
+                    'expense_anomaly': True,
+                    'resource_quota': False,
+                    'recurring_budget': False,
+                    'expiring_budget': False,
+                    'tagging_policy': False,
+                    'id': 'c063973e-0bb2-4134-9ebe-2e68104d7aa8',
+                    'definition': {
+                        'threshold_days': 7,
+                        'threshold': 30,
+                    }
+                },
+                'filters': [{
+                    'filter_name': 'pool',
+                    'filter_values': 'Pool1(b1d60c69-4e14-4bda-be16-dc8fc6d8b941)'
+                }],
+                'limit_hit': {
+                    'created_at': '02/21/2022',
+                    'value': 43,
+                    'link': 'https://20.52.178.55/restapi/v2/resources?'
+                            'start_date=1643673600&end_date=1645142399&'
+                            'breakdownBy=expenses&'
+                            'poolId=b1d60c69-4e14-4bda-be16-dc8fc6d8b941',
+                    'constraint_limit': 22
+                },
+                'user': {
+                    'assignment_id': 'f3b2a722-9674-4042-a08a-81f41b926647',
+                    'assignment_resource_id': '943cb6e0-2cbe-4974-a937-2c480aa9934f',
+                    'assignment_type_id': 2,
+                    'role_id': 3,
+                    'role_name': 'Manager',
+                    'role_purpose': 'optscale_manager',
+                    'role_scope_id': None,
+                    'user_display_name': 'james31',
+                    'user_email': 'james31_pza@hystax.com',
+                    'user_id': '4a50413a-9703-4586-ab39-96aa289e979e'}}}},
+    'new_security_recommendation': {
+        'email': 'test_user@service.com',
+        'subject': 'New security recommendation detected',
+        'template_type': 'new_security_recommendation',
+        'template_params': {
+            'texts': {
+                'title': 'New security recommendation detected',
+                'organization': {
+                    'id': 'b8835bce-da4c-4c29-98a0-4b4967baba53',
+                    'name': 'Czar Pictures',
+                    'currency_code': '$'
+                },
+                'modules': [
+                    {'module': 'Public Amazon S3 buckets',
+                     'count': 1},
+                    {'module': 'Instances with insecure Security Groups settings',
+                     'count': 2},
+                    {'module': 'Inactive IAM users',
+                     'count': 3},
+                    {'module': 'IAM users with unused console access',
+                     'count': 4}
+                ],
+                'user': {
+                    'user_display_name': 'james31'},
+            }}},
+    'saving_spike': {
+        'email': ['james31_pza@hystax.com'],
+        'subject': 'Saving spike',
+        'template_type': 'saving_spike',
+        'template_params': {
+            'texts': {
+                'title': 'Saving spike',
+                'organization': {
+                    'id': '6946211f-47ff-43a3-a9a3-3e5f57d52415',
+                    'name': 'AQA_1617018508.3637385',
+                    'currency_code': '$'
+                },
+                'previous_total': 121.21,
+                'current_total': 145.45,
+                'recommendations': [
+                    {
+                        'count': 3,
+                        'module': 'Abandoned Instances',
+                        'saving': 123,
+                    },
+                    {
+                        'count': 5,
+                        'module': 'Not attached Volumes',
+                        'saving': 22,
+                    },
+                    {
+                        'count': 1,
+                        'module': 'Underutilized Instances',
+                        'saving': 0.45,
+                    }],
+                'user': {
+                    'user_display_name': 'james31'}}}},
+    'organization_policy_quota': {
+        'email': ['james31_pza@hystax.com'],
+        'subject': 'Organization policy violated',
+        'template_type': 'organization_policy_quota',
+        'template_params': {
+            'texts': {
+                'title': 'Organization policy violated',
+                'organization': {
+                    'id': '6946211f-47ff-43a3-a9a3-3e5f57d52415',
+                    'name': 'AQA_1617018508.3637385',
+                    'currency_code': '$'
+                },
+                'organization_constraint': {
+                    'name': 'Resources quota in eu-central-1',
+                    'expiring_budget': False,
+                    'resource_count_anomaly': False,
+                    'expense_anomaly': False,
+                    'resource_quota': True,
+                    'recurring_budget': False,
+                    'tagging_policy': False,
+                    'id': 'c063973e-0bb2-4134-9ebe-2e68104d7aa8',
+                    'definition': {
+                        'max_value': 7,
+                    }
+                },
+                'filters': [{
+                    'filter_name': 'pool',
+                    'filter_values': 'Pool1(b1d60c69-4e14-4bda-be16-dc8fc6d8b941)'
+                }],
+                'limit_hit': {
+                    'created_at': '02/21/2022 11:45 AM UTC',
+                    'value': 22,
+                    'link': 'https://20.52.178.55/resources?'
+                            'breakdownBy=resourceType&region=eu-central-1&'
+                            'startDate=1645401600&endDate=1645487999&'
+                            'poolId=b1d60c69-4e14-4bda-be16-dc8fc6d8b941',
+                    'constraint_limit': 7
+                },
+                'user': {
+                    'user_display_name': 'james31',
+                }}}},
+    'organization_policy_recurring_budget': {
+        'email': ['james31_pza@hystax.com'],
+        'subject': 'Organization policy violated',
+        'template_type': 'organization_policy_recurring_budget',
+        'template_params': {
+            'texts': {
+                'title': 'Organization policy violated',
+                'organization': {
+                    'id': '6946211f-47ff-43a3-a9a3-3e5f57d52415',
+                    'name': 'AQA_1617018508.3637385',
+                    'currency_code': '$'
+                },
+                'organization_constraint': {
+                    'name': 'Monthly limit in eu-central-1',
+                    'expiring_budget': False,
+                    'resource_count_anomaly': False,
+                    'expense_anomaly': False,
+                    'resource_quota': False,
+                    'recurring_budget': True,
+                    'tagging_policy': False,
+                    'id': 'c063973e-0bb2-4134-9ebe-2e68104d7aa8',
+                    'definition': {
+                        'monthly_budget': 1000,
+                    }
+                },
+                'filters': [{
+                    'filter_name': 'pool',
+                    'filter_values': 'Pool1(b1d60c69-4e14-4bda-be16-dc8fc6d8b941)'
+                }],
+                'limit_hit': {
+                    'created_at': '02/21/2022 11:45 AM UTC',
+                    'value': 1557.57,
+                    'link': 'https://20.52.178.55/resources?'
+                            'breakdownBy=expenses&region=eu-central-1&'
+                            'startDate=1645443900&endDate=1646092800&'
+                            'poolId=b1d60c69-4e14-4bda-be16-dc8fc6d8b941',
+                    'constraint_limit': 1000
+                },
+                'user': {
+                    'user_display_name': 'james31',
+                }}}},
+    'organization_policy_expiring_budget': {
+        'email': ['james31_pza@hystax.com'],
+        'subject': 'Organization policy violated',
+        'template_type': 'organization_policy_expiring_budget',
+        'template_params': {
+            'texts': {
+                'title': 'Organization policy violated',
+                'organization': {
+                    'id': '6946211f-47ff-43a3-a9a3-3e5f57d52415',
+                    'name': 'AQA_1617018508.3637385',
+                    'currency_code': '$'
+                },
+                'organization_constraint': {
+                    'name': 'Expenses limit in eu-central-1',
+                    'expiring_budget': True,
+                    'resource_count_anomaly': False,
+                    'expense_anomaly': False,
+                    'resource_quota': False,
+                    'recurring_budget': False,
+                    'tagging_policy': False,
+                    'id': 'c063973e-0bb2-4134-9ebe-2e68104d7aa8',
+                    'definition': {
+                        'total_budget': 1000,
+                        'start_date': 1645443900
+                    }
+                },
+                'filters': [{
+                    'filter_name': 'pool',
+                    'filter_values': 'Pool1(b1d60c69-4e14-4bda-be16-dc8fc6d8b941)'
+                }],
+                'limit_hit': {
+                    'created_at': '02/21/2022 11:45 AM UTC',
+                    'value': 1557.57,
+                    'link': 'https://20.52.178.55/resources?breakdownBy=expenses&'
+                            'region=eu-central-1&startDate=1645443900'
+                            'poolId=b1d60c69-4e14-4bda-be16-dc8fc6d8b941',
+                    'constraint_limit': 1000
+                },
+                'user': {
+                    'user_display_name': 'james31',
+                }}}},
+    'organization_policy_tagging': {
+        'email': ['james31_pza@hystax.com'],
+        'subject': 'Organization policy violated',
+        'template_type': 'organization_policy_tagging',
+        'template_params': {
+            'texts': {
+                'organization': {
+                    'id': '6946211f-47ff-43a3-a9a3-3e5f57d52415',
+                    'name': 'AQA_1617018508.3637385',
+                    'currency_code': '$'
+                },
+                'organization_constraint': {
+                    'name': 'CI/CD resources',
+                    'type': 'Tagging policy',
+                    'id': 'c063973e-0bb2-4134-9ebe-2e68104d7aa8',
+                    'definition': {
+                        'start_date': '02/21/2022 11:45 AM UTC',
+                        'conditions': {'tag': 'CI/CD', 'without_tag': 'owner'}
+                    }
+                },
+                'conditions': 'with tag "CI/CD", without tag "owner"',
+                'limit_hit': {
+                    'created_at': '02/21/2022 11:45 AM UTC',
+                    'value': 22,
+                    'link': 'https://20.52.178.55/resources?'
+                            'breakdownBy=resourceType&region=eu-central-1&'
+                            'startDate=1645401600&endDate=1645487999&'
+                            'poolId=b1d60c69-4e14-4bda-be16-dc8fc6d8b941',
+                    'constraint_limit': 0
+                }}}},
+    'report_imports_passed_for_org': {
+        'email': ['james31_pza@hystax.com'],
+        'subject': 'Expenses initial processing completed',
+        'template_type': 'report_imports_passed_for_org',
+        'template_params': {
+            'texts': {
+                'organization': {
+                    'id': '6946211f-47ff-43a3-a9a3-3e5f57d52415',
+                    'name': 'AQA_1617018508.3637385',
+                    'currency_code': '$'
+                }
+            }
+        }
+    },
+    'insider_prices_sslerror': {
+        "email": ["optscale-staging-notifications@hystax.com"],
+        "subject": "[172.22.20.6] Insider faced Azure SSLError",
+        'template_type': 'insider_prices_sslerror'
+    },
+    'incorrect_alibaba_expenses': {
+        "email": ["optscale-staging-notifications@hystax.com"],
+        "subject": "[172.22.20.6] Incorrect expenses for Alibaba data source",
+        'template_type': 'incorrect_alibaba_expenses',
+        'template_params': {
+            'texts': {
+                'clean_expenses': 18256.11,
+                'cloud_expenses': 17822.97,
+                'period': '2022-11-11 - 2022-11-17',
+                'organization': {
+                    'id': '6946211f-47ff-43a3-a9a3-3e5f57d52415',
+                    'name': 'AQA_1617018508.3637385',
+                },
+                'cloud_account': {
+                    'id': 'c063973e-0bb2-4134-9ebe-2e68104d7aa8',
+                    'name': 'Test_data_source',
+                }}}},
+    'disconnect_survey': {
+        'email': ['andersonmatthew_hwp@hystax.com'],
+        'subject': 'Disconnect Survey [d7092814-2b12-4e60-89c5-67919c9b17d6, Funny company]',
+        'template_type': 'disconnect_survey',
+        'template_params': {
+            'texts': {
+                'user': 'Eliot Alderson',
+                'email': 'ealderson@fsociety.com',
+                'data': [{
+                    'k': 'key1',
+                    'v': 'value1',
+                }, {
+                    'k': 'key2',
+                    'v': 'value2',
+                }],
+                'organization': {
+                    'id': 'd7092814-2b12-4e60-89c5-67919c9b17d6',
+                    'name': 'Funny company',
+                }}}},
+    'restore_password': {
+        'email': ['serviceuser@hystax.com'],
+        'subject': 'FinOps for Cloud password recovery',
+        'template_type': 'restore_password',
+        'template_params': {
+            'texts': {
+                'code': 263308
+            },
+            'links': {
+                'restore_button': 'https://172.22.20.8/password-recovery'
+                                  '?email=serviceuser%40hystax.com&code=263308'
+            }
+        }
+    },
+    'first_task_created': {
+        "email": ["azaza@ma.il"],
+        "subject": "FinOps for Cloud task created notification",
+        "template_type": "first_task_created",
+        "template_params": {
+            "texts": {
+                "organization": {
+                    "id": "5d3d4501-0de8-40dc-a9ed-df2fb1396141",
+                    "name": "am2"
+                },
+                "task": {
+                    "id": "d7092814-2b12-4e60-89c5-67919c9b17d6",
+                    "name": "my task"
+                }
+            },
+        }
+    },
+    'first_run_started': {
+        "email": ["azaza@ma.il"],
+        "subject": "FinOps for Cloud run started notification",
+        "template_type": "first_run_started",
+        "template_params": {
+            "texts": {
+                "organization": {
+                    "id": "5d3d4501-0de8-40dc-a9ed-df2fb1396141",
+                    "name": "am2"
+                },
+                "task": {
+                    "id": "d7092814-2b12-4e60-89c5-67919c9b17d6",
+                    "name": "my task"
+                },
+                "run": {
+                    "id": "6946211f-47ff-43a3-a9a3-3e5f57d52415",
+                    "name": "test run"
+                }
+            },
+        }
+    },
+    'verify_email': {
+        'email': ['serviceuser@hystax.com'],
+        'subject': 'FinOps for Cloud email verification',
+        'template_type': 'verify_email',
+        'template_params': {
+            'texts': {
+                'code': 263308
+            },
+            'links': {
+                'verify_button': 'https://172.22.20.8/email-verification'
+                                 '?email=serviceuser%40hystax.com&code=263308'
+            }
+        }
+    },
+}
+
+OPTSCALE_ROOT_DIR = pathlib.Path(__file__).parent.parent
+EMAIL_TEMPLATES_DIR = OPTSCALE_ROOT_DIR / "herald" / "modules" / "email_generator" / "templates"
+
+def get_template_body(email_type: str) -> str:
+    template_path = EMAIL_TEMPLATES_DIR / f"{email_type}.html"
+    
+    if not template_path.exists():
+        raise FileNotFoundError(f"Template for {email_type} not found.")
+    
+    return template_path.read_text()
+
+def main(email_type: str, template_engine: str = 'jinja2', output_file: pathlib.Path | None = None) -> None:
+    if email_type not in PARAMETER_DUMPS:
+        raise ValueError(f"Invalid email type: {email_type}, must be one of {list(PARAMETER_DUMPS.keys())}")
+        
+    template_body = get_template_body(email_type)
+    template_params = PARAMETER_DUMPS[email_type].get('template_params', {})
+
+    rendered_html_pystache = pystache.render(template_body, template_params)
+    
+    jinja_environment = jinja2.Environment(undefined=jinja2.ChainableUndefined, keep_trailing_newline=True)
+    jinja_template = jinja_environment.from_string(template_body)
+    rendered_html_jinja = jinja_template.render(**template_params)
+    
+    if template_engine == "pystache":
+        rendered_html = rendered_html_pystache
+    elif template_engine == "jinja2":
+        rendered_html = rendered_html_jinja
+    else:
+        raise ValueError(f"Invalid template engine: {template_engine}, must be one of: jinja2, pystache")
+
+    if output_file is not None:
+        with output_file.open('w') as file:
+            file.write(rendered_html)
+            
+        rich.print(
+            f"[green]💾 Rendered template for [yellow]{email_type}[/] using "
+            f"[magenta]{template_engine}[/] saved to [blue]{output_file}[/][/]"
+        )
+    else:
+        rich.print(Syntax(rendered_html, "html", word_wrap=True))
+        rich.print()
+
+    if rendered_html_jinja != rendered_html_pystache:
+        rich.print("[yellow]⚠️ The [magenta]jinja2[/] and [magenta]pystache[/] renderings [bold]differ[/][/]")
+    else:
+        rich.print("[green]✅ The [magenta]jinja2[/] and [magenta]pystache[/] renderings [bold]are the same[/][/]")
+        
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/uv.lock
+++ b/scripts/uv.lock
@@ -1,0 +1,166 @@
+version = 1
+revision = 2
+requires-python = ">=3.13"
+
+[[package]]
+name = "click"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pystache"
+version = "0.6.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/89/0a712ca22930b8c71bced8703e5bb45669c31690ea81afe15f6cb284550c/pystache-0.6.8.tar.gz", hash = "sha256:3707518e6a4d26dd189b07c10c669b1fc17df72684617c327bd3550e7075c72c", size = 101892, upload-time = "2025-03-18T11:54:47.595Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/78/ffd13a516219129cef6a754a11ba2a1c0d69f1e281af4f6bca9ed5327219/pystache-0.6.8-py3-none-any.whl", hash = "sha256:7211e000974a6e06bce2d4d5cad8df03bcfffefd367209117376e4527a1c3cb8", size = 82051, upload-time = "2025-03-18T11:54:45.813Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
+]
+
+[[package]]
+name = "scripts"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pystache" },
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "pystache", specifier = ">=0.6.8" },
+    { name = "typer", specifier = ">=0.15.4" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/89/c527e6c848739be8ceb5c44eb8208c52ea3515c6cf6406aa61932887bf58/typer-0.15.4.tar.gz", hash = "sha256:89507b104f9b6a0730354f27c39fae5b63ccd0c95b1ce1f1a6ba0cfd329997c3", size = 101559, upload-time = "2025-05-14T16:34:57.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/62/d4ba7afe2096d5659ec3db8b15d8665bdcb92a3c6ff0b95e99895b335a9c/typer-0.15.4-py3-none-any.whl", hash = "sha256:eb0651654dcdea706780c466cf06d8f174405a659ffff8f163cfbfee98c0e173", size = 45258, upload-time = "2025-05-14T16:34:55.583Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
+]


### PR DESCRIPTION
## Description

Example usage:

```bash
$ cd scripts
$ uv run render_email_template.py first_task_created --template-engine jinja2 --output-file /tmp/test.html
```

If you omit `--output-file` it will render the template to `stdout`. Also added a check at the end to show whether the template engine used makes a difference (important to verify backwards compatibility) and after testing it with several templates it always passes

## Related issue number

<!-- Please link a pull request to an issue by using "fixes #10" style references to close the issue when this PR is merged. -->

## Special notes

<!-- Please provide additional information if required. -->

## Checklist

* [ ] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist
* [ ] New and existing unit tests pass locally