### PR TITLE
MPT-10773 - slow tests redirect

### DIFF
--- a/e2etests/pages/base-page.ts
+++ b/e2etests/pages/base-page.ts
@@ -1,5 +1,4 @@
 import {Locator, Page} from "@playwright/test";
-
         /**
          * Abstract class representing the base structure for all pages.
          * This class provides common functionality for interacting with web pages in Playwright tests.
@@ -19,14 +18,13 @@ import {Locator, Page} from "@playwright/test";
                 this.url = url;
                 this.main = this.page.locator('main');
             }
-        
+
             /**
              * Navigates to the URL of the page.
-             * @param {boolean} [waitForPageLoad=false] - Whether to wait for the page to fully load.
              * @returns {Promise<void>} A promise that resolves when the navigation is complete.
              */
-            async navigateToURL(waitForPageLoad = false): Promise<void> {
-                await this.page.goto(this.url, {waitUntil: waitForPageLoad ? "networkidle" : "domcontentloaded"});
+            async navigateToURL(customUrl: string = null): Promise<void> {
+                await this.page.goto( customUrl ? customUrl : this.url, {waitUntil: "load"});
             }
 
             /**
@@ -36,7 +34,7 @@ import {Locator, Page} from "@playwright/test";
              * @param {boolean} [closeList=false] - Whether to close the list after selecting the option.
              * @returns {Promise<void>} A promise that resolves when the option is selected.
              */
-            async selectFromComboBox(comboBox: Locator, option: string, closeList = false): Promise<void> {
+            async selectFromComboBox(comboBox: Locator, option: string, closeList: boolean = false): Promise<void> {
                 await comboBox.click();
                 await this.page.getByRole('option', {name: option, exact: true}).click();
                 if (closeList) await this.page.locator('body').click();
@@ -140,7 +138,7 @@ import {Locator, Page} from "@playwright/test";
              * @param {number} [timeout=5000] - The delay duration in milliseconds.
              * @returns {Promise<void>} A promise that resolves after the specified timeout.
              */
-            async screenshotUpdateDelay(timeout = 5000): Promise<void> {
+            async screenshotUpdateDelay(timeout: number = 5000): Promise<void> {
                 if (process.env.SCREENSHOT_UPDATE_DELAY === 'true') {
                     console.log(`Waiting for ${timeout}ms for screenshot update...`);
                     await this.page.waitForTimeout(timeout);

--- a/e2etests/pages/login-page.ts
+++ b/e2etests/pages/login-page.ts
@@ -32,7 +32,7 @@ export class LoginPage extends BasePage {
      * @returns {Promise<void>}
      */
     async login(email: string, password: string) {
-        await this.navigateToURL(true);
+        await this.navigateToURL();
         await this.emailInput.fill(email);
         await this.passwordInput.fill(password);
         await this.loginBtn.click();

--- a/e2etests/pages/resources-page.ts
+++ b/e2etests/pages/resources-page.ts
@@ -46,7 +46,7 @@ import {BasePage} from "./base-page";
          * @param {Page} page - The Playwright page object.
          */
         constructor(page: Page) {
-            super(page, '/resources');
+            super(page, '/resources?breakdownBy=expenses&categorizedBy=service_name&expenses=daily&withLegend=true');
             this.heading = this.main.getByTestId('lbl_resources');
             this.perspectivesBtn = this.main.getByRole('button', {name: 'Perspectives'});
             this.savePerspectiveBtn = this.main.getByRole('button', {name: 'Save perspective'});

--- a/e2etests/playwright.regression.config.ts
+++ b/e2etests/playwright.regression.config.ts
@@ -16,9 +16,9 @@ export default defineConfig({
   testIgnore: ['**/snapshots/**'],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: 1,
-  workers: process.env.CI ? 1 : 3,
-  timeout: 40000,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : 3,
+  timeout: 30000,
   reporter: [
     ["list"],
     ["json", {outputFile: "results.json"}],
@@ -32,7 +32,7 @@ export default defineConfig({
   },
   use: {
     baseURL: baseURL,
-    actionTimeout: 40000,
+    actionTimeout: 15000,
     testIdAttribute: 'data-test-id',
     headless: true,
     trace: "retain-on-failure",

--- a/e2etests/regression-tests/tests/swo-regression-tests.spec.ts
+++ b/e2etests/regression-tests/tests/swo-regression-tests.spec.ts
@@ -1,6 +1,6 @@
 import {test} from "../../fixtures/page-fixture";
 import {expect} from "@playwright/test";
-import {setLocalforageRoot} from "../../utils/localforge-auth/localforage-service";
+import {restoreUserSessionInLocalForage} from "../../utils/localforge-auth/localforage-service";
 import {EStorageState} from "../../utils/enums";
 import {roundElementDimensions} from "../utils/roundElementDimensions";
 
@@ -8,67 +8,69 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
   test.use({storageState: EStorageState.liveDemoUser});
 
   test.beforeEach('Restore live-demo user session', async ({page}) => {
-    await setLocalforageRoot(page);
+    await restoreUserSessionInLocalForage(page);
   })
 
-  test("Validate UI consistency of Header and Main Menu", async ({homePage, header, mainMenu}) => {
+  test("UI consistency of Header and Main Menu", async ({homePage, header, mainMenu}) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
-    await homePage.navigateToURL(true);
-    await test.step('Verify header', async () => {
+    await homePage.setupApiInterceptions();
+    await homePage.navigateToURL();
+    await homePage.waitForAllCanvases();
+    await test.step('Header widget', async () => {
       await homePage.screenshotUpdateDelay();
       await roundElementDimensions(header.header);
       await expect(header.header).toHaveScreenshot('Header-screenshot.png');
     });
 
-    await test.step('Verify Main Menu', async () => {
+    await test.step('Main Menu widget', async () => {
       await homePage.screenshotUpdateDelay();
       await roundElementDimensions(mainMenu.menu);
       await expect(mainMenu.menu).toHaveScreenshot('MainMenu-screenshot.png');
     });
   })
 
-  test('Validate Homepage blocks against baseline screenshots', async ({homePage}) => {
+  test('Homepage blocks against baseline screenshots', async ({homePage}) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await homePage.setupApiInterceptions();
-      await homePage.navigateToURL(true);
+      await homePage.navigateToURL();
       await homePage.waitForAllCanvases();
       await homePage.screenshotUpdateDelay();
     });
-    await test.step('Verify Home Page OrganizationExpensesBlock', async () => {
+    await test.step('Organization Expenses Block', async () => {
       await roundElementDimensions(homePage.organizationExpensesBlock);
       await expect(homePage.organizationExpensesBlock).toHaveScreenshot('OrganizationExpensesBlock-screenshot.png');
     });
-    await test.step('Verify Home Page TopResourcesBlock', async () => {
+    await test.step('TopResources Block', async () => {
       await roundElementDimensions(homePage.topResourcesBlock);
       await expect(homePage.topResourcesBlock).toHaveScreenshot('TopResourcesBlock-screenshot.png');
     });
 
-    await test.step('Verify Home Page RecommendationsBlock', async () => {
+    await test.step('Recommendations Block', async () => {
       await roundElementDimensions(homePage.recommendationsBlock);
       await expect(homePage.recommendationsBlock).toHaveScreenshot('RecommendationsBlock-screenshot.png');
     });
 
-    await test.step('Verify Home Page PolicyViolationsBlock', async () => {
+    await test.step('PolicyViolations Block', async () => {
       await roundElementDimensions(homePage.policyViolationsBlock);
       await expect(homePage.policyViolationsBlock).toHaveScreenshot('PolicyViolationsBlock-screenshot.png');
     });
 
-    await test.step('Verify Home Page PoolsRequiringAttentionBlock', async () => {
+    await test.step('Pools Requiring Attention Block', async () => {
       await roundElementDimensions(homePage.poolsRequiringAttentionBlock);
       await expect(homePage.poolsRequiringAttentionBlock).toHaveScreenshot('PoolsRequiringAttentionBlock-screenshot.png');
     });
   });
 
 
-  test('Verify Recommendations page matches screenshots', async ({recommendationsPage}) => {
+  test('Recommendations page matches screenshots', async ({recommendationsPage}) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await recommendationsPage.setupApiInterceptions();
-      await recommendationsPage.navigateToURL(true);
+      await recommendationsPage.navigateToURL();
     });
 
-    await test.step('Verify Recommendations page content - cards', async () => {
+    await test.step('Page view cards', async () => {
       await recommendationsPage.clickCardsButtonIfNotActive();
       await recommendationsPage.screenshotUpdateDelay();
       await roundElementDimensions(recommendationsPage.main);
@@ -79,7 +81,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(recommendationsPage.firstCard).toHaveScreenshot('Recommendations-cards-first-card-screenshot.png');
     });
 
-    await test.step('Verify Recommendations page content - table', async () => {
+    await test.step('Page view table', async () => {
       await recommendationsPage.clickTableButton();
       await recommendationsPage.screenshotUpdateDelay();
       await roundElementDimensions(recommendationsPage.main);
@@ -91,14 +93,14 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
   })
 
-  test('Verify Resources page matches screenshots', async ({resourcesPage}) => {
+  test('Resources page matches screenshots', async ({resourcesPage}) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await resourcesPage.setupApiInterceptions();
-      await resourcesPage.page.goto('/resources?breakdownBy=expenses&categorizedBy=service_name&expenses=daily&withLegend=true')
+      await resourcesPage.navigateToURL();
     });
 
-    await test.step('Verify Resources page on landing', async () => {
+    await test.step('View type - Default', async () => {
       await resourcesPage.waitForCanvas();
       await resourcesPage.searchInput.waitFor();
       await resourcesPage.heading.hover();
@@ -107,7 +109,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(resourcesPage.main).toHaveScreenshot('Resources-landing-screenshot.png');
     });
 
-    await test.step('Verify Resources page breakdown by expenses', async () => {
+    await test.step('View type - breakdown by expenses', async () => {
       await resourcesPage.clickCardsExpensesIfNotActive();
       await resourcesPage.heading.hover();
       await resourcesPage.expensesBreakdownChart.waitFor();
@@ -117,7 +119,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(resourcesPage.expensesBreakdownChart).toHaveScreenshot('Resources-expenses-chart-screenshot.png');
     });
 
-    await test.step('Verify Resources page breakdown by tags', async () => {
+    await test.step('View type - breakdown by tags', async () => {
       await resourcesPage.tagsBtn.click();
       await resourcesPage.heading.hover();
       await resourcesPage.tagsBreakdownChart.waitFor();
@@ -127,7 +129,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(resourcesPage.tagsBreakdownChart).toHaveScreenshot('Resources-tags-chart-screenshot.png');
     });
 
-    await test.step('Verify Resources page breakdown by resource count', async () => {
+    await test.step('View type - breakdown by resource count', async () => {
       await resourcesPage.resourceCountBtn.click();
       await resourcesPage.heading.hover();
       await resourcesPage.resourceCountBreakdownChart.waitFor();
@@ -138,7 +140,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
   })
 
-  test('Verify Resource details page matches screenshots', async ({
+  test('Resource details page matches screenshots', async ({
                                                                              resourcesPage,
                                                                              resourceDetailsPage
                                                                            }) => {
@@ -149,7 +151,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
 
     await test.step('Navigate to Resource details page for Sunflower EU Fra', async () => {
-      await resourcesPage.page.goto('/resources?breakdownBy=expenses&categorizedBy=service_name&expenses=daily&withLegend=true');
+      await resourcesPage.navigateToURL('/resources?breakdownBy=expenses&categorizedBy=service_name&expenses=daily&withLegend=true');
       await resourcesPage.waitForCanvas();
 
       // Click on the resource name link in the first row to ensure it exists in the live database before navigating
@@ -158,7 +160,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await resourceDetailsPage.waitForTextContent(resourceDetailsPage.heading, 'Details of sunflower-eu-fra');
     });
 
-    await test.step('Verify Resource details page content - Details tab', async () => {
+    await test.step('View type - Details tab', async () => {
       if (!await resourceDetailsPage.isTabSelected(resourceDetailsPage.detailsTab)) await resourceDetailsPage.clickDetailsTab();
       await resourceDetailsPage.heading.hover();
       await resourceDetailsPage.screenshotUpdateDelay();
@@ -166,7 +168,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(resourceDetailsPage.main).toHaveScreenshot('ResourceDetails-details-tab-screenshot.png');
     });
 
-    await test.step('Verify Resource details page content - Constraints tab', async () => {
+    await test.step('View type - Constraints tab', async () => {
       await resourceDetailsPage.clickConstraintsTab();
       await resourceDetailsPage.heading.hover();
       await resourceDetailsPage.constraintsTable.waitFor();
@@ -175,7 +177,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(resourceDetailsPage.main).toHaveScreenshot('ResourceDetails-constraints-tab-screenshot.png');
     });
 
-    await test.step('Verify Resource details page content - Expenses tab', async () => {
+    await test.step('View type - Expenses tab', async () => {
       await resourceDetailsPage.clickExpensesTab();
       await resourceDetailsPage.clickExpensesGroupedButtonIfNotActive();
       await resourceDetailsPage.heading.hover();
@@ -191,7 +193,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(resourceDetailsPage.main).toHaveScreenshot('ResourceDetails-expenses-tab-detailed-screenshot.png');
     });
 
-    await test.step('Verify Resource details page content - Recommendations tab', async () => {
+    await test.step('View type - Recommendations tab', async () => {
       await resourceDetailsPage.clickRecommendationsTab();
       await resourceDetailsPage.heading.hover();
       await resourceDetailsPage.screenshotUpdateDelay();
@@ -200,24 +202,24 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
   })
 
-  test('Verify Pools page matches screenshots', async ({poolsPage}) => {
+  test('Pools page matches screenshots', async ({poolsPage}) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await poolsPage.setupApiInterceptions();
     });
 
     await test.step('Navigate to Pools page', async () => {
-      await poolsPage.navigateToURL(true);
+      await poolsPage.navigateToURL();
     });
 
-    await test.step('Verify Pools page content', async () => {
+    await test.step('View type - Default', async () => {
       await poolsPage.heading.hover();
       await poolsPage.screenshotUpdateDelay();
       await roundElementDimensions(poolsPage.main);
       await expect(poolsPage.main).toHaveScreenshot('Pools-landing-screenshot.png');
     });
 
-    await test.step('Verify Pools page with expanded requiring attention', async () => {
+    await test.step('View type - with expanded requiring attention', async () => {
       await poolsPage.clickExpandRequiringAttentionBtn();
       await poolsPage.heading.hover();
       await poolsPage.screenshotUpdateDelay();
@@ -226,17 +228,17 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
   });
 
-  test('Verify Expenses page matches screenshots', async ({expensesPage}) => {
+  test('Expenses page matches screenshots', async ({expensesPage}) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await expensesPage.setupApiInterceptions();
     });
 
     await test.step('Navigate to Expenses page', async () => {
-      await expensesPage.navigateToURL(true);
+      await expensesPage.navigateToURL();
     });
 
-    await test.step('Verify Expenses page content - daily selected', async () => {
+    await test.step('View type - daily selected', async () => {
       await expensesPage.clickDailyBtnIfNotSelected();
       await expensesPage.heading.hover();
       await expensesPage.waitForCanvas();
@@ -245,7 +247,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(expensesPage.main).toHaveScreenshot('Expenses-daily-screenshot.png');
     });
 
-    await test.step('Verify Expenses page content - weekly selected', async () => {
+    await test.step('View type - weekly selected', async () => {
       await expensesPage.clickWeeklyBtn();
       await expensesPage.heading.hover();
       await expensesPage.waitForCanvas();
@@ -254,7 +256,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(expensesPage.main).toHaveScreenshot('Expenses-weekly-screenshot.png');
     });
 
-    await test.step('Verify Expenses page content - monthly selected', async () => {
+    await test.step('View type - monthly selected', async () => {
       await expensesPage.clickMonthlyBtn();
       await expensesPage.heading.hover();
       await expensesPage.waitForCanvas();
@@ -264,17 +266,17 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
   });
 
-  test('Verify Expenses page breakdowns matches screenshots', async ({expensesPage}) => {
+  test('Expenses page breakdowns matches screenshots', async ({expensesPage}) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await expensesPage.setupApiInterceptions();
     });
 
     await test.step('Navigate to Expenses page', async () => {
-      await expensesPage.navigateToURL(true);
+      await expensesPage.navigateToURL();
     });
 
-    await test.step('Verify Expenses page breakdowns - source', async () => {
+    await test.step('View type - breakdown by source', async () => {
       await expensesPage.clickSourceBtn();
 
       await expensesPage.dataSourceHeading.hover();
@@ -285,7 +287,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
 
     });
 
-    await test.step('Verify Expenses page breakdowns - pool', async () => {
+    await test.step('View type- breakdown by pool', async () => {
       await expensesPage.clickCostExploreBreadcrumb();
       await expensesPage.clickPoolBtn();
       await expensesPage.poolHeading.hover();
@@ -295,7 +297,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(expensesPage.main).toHaveScreenshot('Expenses-pool-screenshot.png');
     });
 
-    await test.step('Verify Expenses page breakdowns - owner', async () => {
+    await test.step('View type - breakdown by owner', async () => {
       await expensesPage.clickCostExploreBreadcrumb();
       await expensesPage.clickOwnerBtn();
       await expensesPage.ownerHeading.hover();
@@ -306,17 +308,17 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
   });
 
-  test('Verify Anomalies page matches screenshots', async ({anomaliesPage, anomaliesCreatePage}) => {
+  test('Anomalies page matches screenshots', async ({anomaliesPage, anomaliesCreatePage}) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await anomaliesPage.setupApiInterceptions();
     });
 
     await test.step('Navigate to Anomalies page', async () => {
-      await anomaliesPage.navigateToURL(true);
+      await anomaliesPage.navigateToURL();
     });
 
-    await test.step('Verify Anomalies page content', async () => {
+    await test.step('Page content', async () => {
       await anomaliesPage.heading.hover();
       await anomaliesPage.waitForCanvas();
       await anomaliesPage.screenshotUpdateDelay();
@@ -324,7 +326,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(anomaliesPage.main).toHaveScreenshot('Anomalies-screenshot.png');
     });
 
-    await test.step('Verify create anomaly page', async () => {
+    await test.step('Create anomaly page', async () => {
       await anomaliesPage.clickAddBtn();
       await anomaliesCreatePage.withoutTagFilter.waitFor();
       await anomaliesPage.screenshotUpdateDelay();
@@ -333,24 +335,24 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
   })
 
-  test('Verify Policies page matches screenshots', async ({policiesPage, policiesCreatePage}) => {
+  test('Policies page matches screenshots', async ({policiesPage, policiesCreatePage}) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await policiesPage.setupApiInterceptions();
     });
 
     await test.step('Navigate to Policies page', async () => {
-      await policiesPage.navigateToURL(true);
+      await policiesPage.navigateToURL();
     });
 
-    await test.step('Verify Policies page content', async () => {
+    await test.step('Page content', async () => {
       await policiesPage.heading.hover();
       await policiesPage.screenshotUpdateDelay();
       await roundElementDimensions(policiesPage.main);
       await expect(policiesPage.main).toHaveScreenshot('Policies-screenshot.png');
     });
 
-    await test.step('Verify create policy page', async () => {
+    await test.step('Create policy page', async () => {
       await policiesPage.clickAddBtn();
       await policiesCreatePage.heading.hover();
       await policiesCreatePage.withoutTagFilter.waitFor();
@@ -360,7 +362,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
   })
 
-  test('Verify Tagging Policies page matches screenshots', async ({
+  test('Tagging Policies page matches screenshots', async ({
                                                                              taggingPoliciesPage,
                                                                              taggingPoliciesCreatePage
                                                                            }) => {
@@ -370,17 +372,17 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
 
     await test.step('Navigate to Tagging Policies page', async () => {
-      await taggingPoliciesPage.navigateToURL(true);
+      await taggingPoliciesPage.navigateToURL();
     });
 
-    await test.step('Verify Tagging Policies page content', async () => {
+    await test.step('Page content', async () => {
       await taggingPoliciesPage.heading.hover();
       await taggingPoliciesPage.screenshotUpdateDelay();
       await roundElementDimensions(taggingPoliciesPage.main);
       await expect(taggingPoliciesPage.main).toHaveScreenshot('TaggingPolicies-screenshot.png');
     });
 
-    await test.step('Verify create tagging policy page', async () => {
+    await test.step('Create tagging policy page', async () => {
       await taggingPoliciesPage.clickAddBtn();
       await taggingPoliciesCreatePage.k8ServiceFilter.waitFor();
       await taggingPoliciesCreatePage.heading.hover();
@@ -390,24 +392,24 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
   })
 
-  test('Verify Users page matches screenshots', async ({usersPage, usersInvitePage}) => {
+  test('Users page matches screenshots', async ({usersPage, usersInvitePage}) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await usersPage.setupApiInterceptions();
     });
 
     await test.step('Navigate to Users page', async () => {
-      await usersPage.navigateToURL(true);
+      await usersPage.navigateToURL();
     });
 
-    await test.step('Verify Users page content', async () => {
+    await test.step('Page content', async () => {
       await usersPage.heading.hover();
       await usersPage.screenshotUpdateDelay();
       await roundElementDimensions(usersPage.main);
       await expect(usersPage.main).toHaveScreenshot('Users-screenshot.png');
     });
 
-    await test.step('Verify invite user page', async () => {
+    await test.step('Invite user page', async () => {
       await usersPage.clickInviteBtn();
       await usersPage.screenshotUpdateDelay();
       await roundElementDimensions(usersInvitePage.main);
@@ -415,7 +417,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
   })
 
-  test('Verify Cloud Account page matches screenshots', async ({
+  test('Cloud Account page matches screenshots', async ({
                                                                           cloudAccountsPage,
                                                                           cloudAccountsConnectPage
                                                                         }) => {
@@ -425,17 +427,17 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
 
     await test.step('Navigate to Cloud Accounts page', async () => {
-      await cloudAccountsPage.navigateToURL(true);
+      await cloudAccountsPage.navigateToURL();
     });
 
-    await test.step('Verify Cloud Accounts page content', async () => {
+    await test.step('Page content', async () => {
       await cloudAccountsPage.heading.hover();
       await cloudAccountsPage.screenshotUpdateDelay();
       await roundElementDimensions(cloudAccountsPage.main);
       await expect(cloudAccountsPage.main).toHaveScreenshot('CloudAccounts-screenshot.png');
     });
 
-    await test.step('Verify Cloud Accounts connect page - AWS Root', async () => {
+    await test.step('Connect page - AWS Root', async () => {
       await cloudAccountsPage.clickAddBtn();
       await cloudAccountsConnectPage.clickDataSourceTileIfNotActive(cloudAccountsConnectPage.awsRootBtn);
       await cloudAccountsConnectPage.toggleCheckbox(cloudAccountsConnectPage.automaticallyDetectExistingDataSourcesCheckbox);
@@ -445,7 +447,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(cloudAccountsConnectPage.main).toHaveScreenshot('CloudAccounts-connect-aws-root-screenshot.png');
     });
 
-    await test.step('Verify Cloud Accounts connect page - Azure Tenant', async () => {
+    await test.step('Connect page - Azure Tenant', async () => {
       await cloudAccountsConnectPage.clickAzureTenant();
       await cloudAccountsConnectPage.heading.hover();
       await cloudAccountsConnectPage.screenshotUpdateDelay();
@@ -453,7 +455,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(cloudAccountsConnectPage.main).toHaveScreenshot('CloudAccounts-connect-azure-tenant-screenshot.png');
     });
 
-    await test.step('Verify Cloud Accounts connect page - Google Cloud', async () => {
+    await test.step('Connect page - Google Cloud', async () => {
       await cloudAccountsConnectPage.clickGoogleCloud();
       await cloudAccountsConnectPage.heading.hover();
       await cloudAccountsConnectPage.screenshotUpdateDelay();
@@ -461,7 +463,7 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
       await expect(cloudAccountsConnectPage.main).toHaveScreenshot('CloudAccounts-connect-google-cloud-screenshot.png');
     });
 
-    await test.step('Verify Cloud Accounts connect page - Google Cloud Tenant', async () => {
+    await test.step('Connect page - Google Cloud Tenant', async () => {
       await cloudAccountsConnectPage.clickGoogleCloudTenant();
       await cloudAccountsConnectPage.heading.hover();
       await cloudAccountsConnectPage.screenshotUpdateDelay();
@@ -470,17 +472,17 @@ test.describe('FinOps UI Visual Regression @swo_regression', () => {
     });
   })
 
-  test('Verify Events page matches screenshots', async ({eventsPage}) => {
+  test('Events page matches screenshots', async ({eventsPage}) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await eventsPage.setupApiInterceptions();
     });
 
     await test.step('Navigate to Events page', async () => {
-      await eventsPage.navigateToURL(true);
+      await eventsPage.navigateToURL();
     });
 
-    await test.step('Verify Events page content', async () => {
+    await test.step('Page content', async () => {
       await eventsPage.heading.hover();
       await eventsPage.screenshotUpdateDelay();
       await roundElementDimensions(eventsPage.main);

--- a/e2etests/setup/auth-live-demo.setup.ts
+++ b/e2etests/setup/auth-live-demo.setup.ts
@@ -5,14 +5,13 @@ import {safeWriteJsonFile} from "../utils/file";
 
 setup('Login as live demo user', async ({ page }) => {
   await setup.step('Navigate to Live Demo', async () => {
-    await page.goto('/live-demo', { waitUntil: 'networkidle' });
+    await page.goto('/live-demo', { waitUntil: 'domcontentloaded', timeout: 20000 });
   });
 
   await setup.step('Fill User Email and Proceed', async () => {
     const email = process.env.DEFAULT_USER_EMAIL || 'FinOpsTest1@outlook.com';
 
     await injectLocalforage(page);
-
     await page.getByTestId('input_email').fill(email);
     await page.getByTestId('btn_proceed_to_live_demo').click();
     await page.getByRole('button', { name: 'Next' }).click();

--- a/e2etests/utils/localforge-auth/localforage-service.ts
+++ b/e2etests/utils/localforge-auth/localforage-service.ts
@@ -1,35 +1,12 @@
-import {expect, Page} from '@playwright/test';
+import {Page} from '@playwright/test';
 import {safeReadJsonFile} from "../file";
 import {EStorageState} from "../enums";
 import path from 'path';
 
-export async function injectLocalforage(page: Page, retries = 3) {
-  const isAlreadyLoaded = await page.evaluate(() => {
-    return typeof (window as any).localforage !== 'undefined';
-  });
-
-  if (isAlreadyLoaded) return;
-
-  const scriptPath = path.resolve(__dirname, './script/localforage.min.js'); // Adjust path
-
-  for (let attempt = 0; attempt < retries; attempt++) {
-
-    await page.addScriptTag({ path: scriptPath });
-
-    const isLoaded = await page.evaluate(() => {
-      const lf = (window as any).localforage;
-      return typeof lf !== 'undefined' && typeof lf.setItem === 'function';
-    });
-
-    if (isLoaded) {
-      expect(isLoaded).toBeTruthy();
-      return;
-    }
-
-    await page.waitForTimeout(500);
-  }
-
-  expect(false).toBeTruthy(); // Force failure if all retries fail
+export async function injectLocalforage(page: Page) {
+  const scriptPath = path.resolve(__dirname, './script/localforage.min.js');
+  await page.addScriptTag({path: scriptPath});
+  await page.waitForTimeout(200); // wait for script to fully attach
 }
 
 export async function getLocalforageRoot(page: Page) {
@@ -43,15 +20,26 @@ export async function getLocalforageRoot(page: Page) {
   });
 }
 
-export async function setLocalforageRoot(page: Page) {
-  const authData = safeReadJsonFile(EStorageState.liveDemoUser);
-  await page.goto('/');
-  await page.waitForLoadState('domcontentloaded'); // ensure scripts can be injected
-
+export async function restoreUserSessionInLocalForage(page: Page) {
+  const sessionData =  safeReadJsonFile(EStorageState.liveDemoUser);
+  await page.goto('/', {waitUntil: 'domcontentloaded'});
   await injectLocalforage(page);
   await page.evaluate((data) => {
     const lf = (window as any).localforage;
     return lf.setItem('root', data.localforageStoredSession.root);
-  }, authData);
+  }, sessionData);
+
+  await page.waitForFunction(
+    (expected) => {
+      const lf = (window as any).localforage;
+      if (!lf) return false;
+      return lf.getItem('root').then((stored) => {
+        return JSON.stringify(stored) === JSON.stringify(expected);
+      });
+    },
+    sessionData,
+    {timeout: 1000}
+  );
+
   await page.clock.setFixedTime(new Date('2025-01-25T12:00:00Z'));
 }

--- a/ngui/ui/src/layouts/BaseLayout/BaseLayout.tsx
+++ b/ngui/ui/src/layouts/BaseLayout/BaseLayout.tsx
@@ -139,7 +139,7 @@ const BaseLayout = ({ children, showMainMenu = false, showOrganizationSelector =
           if (someApiLoading) {
             return (
               <PageContentWrapper>
-                <div className={classes.preloaderOverlay}>
+                <div data-testid="mainPreloader" className={classes.preloaderOverlay}>
                   <img src={preloaderLogo} alt="Loading page" />
                 </div>
               </PageContentWrapper>


### PR DESCRIPTION
## Description
- Added a check to prevent unnecessary navigation to the same URL.
- Ensured the main locator waits for visibility, improving test reliability.
- Updated the number of Playwright config retries and workers for CI/CD pipelines.

## Related issue number
MPT-10773
