### PR TITLE
feat: Improve the cloud account pagination to work with python filters (MPT-8485)

### DIFF
--- a/jira_bus/jira_bus_server/server.py
+++ b/jira_bus/jira_bus_server/server.py
@@ -2,49 +2,38 @@ import argparse
 import logging
 import os
 
-import pydevd_pycharm
 import tornado.ioloop
 import tornado.web
 from etcd import Lock as EtcdLock
 
+import optscale_client.config_client.client
 from jira_bus.jira_bus_server.constants import backend_urls
-from jira_bus.jira_bus_server.handlers.v2.app_descriptor import AppDescriptorHandler
+from jira_bus.jira_bus_server.handlers.v2.app_descriptor import \
+    AppDescriptorHandler
 from jira_bus.jira_bus_server.handlers.v2.app_hook import (
-    AppHookIssueUpdatedHandler,
-    AppHookIssueDeletedHandler,
-)
-from jira_bus.jira_bus_server.handlers.v2.app_lifecycle import (
-    AppLifecycleInstalledHandler,
-)
+    AppHookIssueDeletedHandler, AppHookIssueUpdatedHandler)
+from jira_bus.jira_bus_server.handlers.v2.app_lifecycle import \
+    AppLifecycleInstalledHandler
+from jira_bus.jira_bus_server.handlers.v2.authorize import AuthorizeHandler
 from jira_bus.jira_bus_server.handlers.v2.base import DefaultHandler
 from jira_bus.jira_bus_server.handlers.v2.issue_attachment import (
-    IssueAttachmentCollectionHandler,
-    IssueAttachmentItemHandler,
-)
+    IssueAttachmentCollectionHandler, IssueAttachmentItemHandler)
 from jira_bus.jira_bus_server.handlers.v2.issue_info import IssueInfoHandler
-from jira_bus.jira_bus_server.handlers.v2.authorize import AuthorizeHandler
-from jira_bus.jira_bus_server.handlers.v2.organization_assignment import (
-    OrganizationAssignmentHandler,
-)
-from jira_bus.jira_bus_server.handlers.v2.organization import (
-    OrganizationCollectionHandler,
-)
-from jira_bus.jira_bus_server.handlers.v2.organization_status import (
-    OrganizationStatusHandler,
-)
+from jira_bus.jira_bus_server.handlers.v2.organization import \
+    OrganizationCollectionHandler
+from jira_bus.jira_bus_server.handlers.v2.organization_assignment import \
+    OrganizationAssignmentHandler
+from jira_bus.jira_bus_server.handlers.v2.organization_status import \
+    OrganizationStatusHandler
 from jira_bus.jira_bus_server.handlers.v2.shareable_book import (
-    ShareableBookCollectionHandler,
-    ShareableBookItemHandler,
-)
-from jira_bus.jira_bus_server.handlers.v2.shareable_resource import (
-    ShareableResourceHandler,
-)
-from jira_bus.jira_bus_server.handlers.v2.swagger import SwaggerStaticFileHandler
-from jira_bus.jira_bus_server.handlers.v2.user_assignment import UserAssignmentHandler
-from jira_bus.jira_bus_server.models.db_factory import DBType, DBFactory
-
-import optscale_client.config_client.client
-
+    ShareableBookCollectionHandler, ShareableBookItemHandler)
+from jira_bus.jira_bus_server.handlers.v2.shareable_resource import \
+    ShareableResourceHandler
+from jira_bus.jira_bus_server.handlers.v2.swagger import \
+    SwaggerStaticFileHandler
+from jira_bus.jira_bus_server.handlers.v2.user_assignment import \
+    UserAssignmentHandler
+from jira_bus.jira_bus_server.models.db_factory import DBFactory, DBType
 
 DEFAULT_PORT = 8977
 DEFAULT_ETCD_HOST = "etcd"
@@ -144,6 +133,11 @@ def make_app(db_type, etcd_host, etcd_port, wait=False):
 
 def main():
     if os.environ.get("PYCHARM_DEBUG_HOST"):
+        # NOTE: Intentionally importing it here as the module applies logic
+        #       on import time which breaks the built-in python debugger (pdb) 
+        
+        import pydevd_pycharm
+        
         pydevd_pycharm.settrace(
             host=os.environ["PYCHARM_DEBUG_HOST"],
             port=int(os.environ.get("PYCHARM_DEBUG_PORT", 3000)),

--- a/rest_api/rest_api_server/controllers/employee.py
+++ b/rest_api/rest_api_server/controllers/employee.py
@@ -1,38 +1,41 @@
 import logging
 import re
-import requests
 from datetime import datetime, timezone
-from optscale_client.config_client.client import etcd
-from sqlalchemy import exists, and_, or_, func
-from sqlalchemy.exc import IntegrityError
-from tools.optscale_exceptions.common_exc import (
-    NotFoundException, ConflictException, ForbiddenException,
-    UnauthorizedException, WrongArgumentsException)
 
-from rest_api.rest_api_server.controllers.base import (
-    BaseController, MongoMixin)
-from rest_api.rest_api_server.controllers.base_async import (
-    BaseAsyncControllerWrapper)
+import requests
+from currency_symbols.currency_symbols import CURRENCY_SYMBOLS_MAP
+from sqlalchemy import and_, exists, func, or_
+from sqlalchemy.exc import IntegrityError
+
+from optscale_client.auth_client.client_v2 import Client as AuthClient
+from optscale_client.config_client.client import etcd
+from optscale_client.herald_client.client_v2 import Client as HeraldClient
+from rest_api.rest_api_server.controllers.base import (BaseController,
+                                                       MongoMixin)
+from rest_api.rest_api_server.controllers.base_async import \
+    BaseAsyncControllerWrapper
+from rest_api.rest_api_server.controllers.employee_email import \
+    EmployeeEmailController
 from rest_api.rest_api_server.controllers.expense import (
     CloudFilteredEmployeeFormattedExpenseController,
     PoolFilteredEmployeeFormattedExpenseController)
-from rest_api.rest_api_server.controllers.organization_constraint import (
-    OrganizationConstraintController)
-from rest_api.rest_api_server.controllers.profiling.base import (
-    BaseProfilingController)
-from rest_api.rest_api_server.controllers.employee_email import (
-    EmployeeEmailController)
+from rest_api.rest_api_server.controllers.organization_constraint import \
+    OrganizationConstraintController
+from rest_api.rest_api_server.controllers.profiling.base import \
+    BaseProfilingController
 from rest_api.rest_api_server.exceptions import Err
-from rest_api.rest_api_server.models.enums import (
-    AuthenticationType, PoolPurposes, RolePurposes)
-from rest_api.rest_api_server.models.models import (
-    AssignmentRequest, Employee, EmployeeEmail, Layout, Organization, Pool,
-    Rule, ShareableBooking)
+from rest_api.rest_api_server.models.enums import (AuthenticationType,
+                                                   PoolPurposes, RolePurposes)
+from rest_api.rest_api_server.models.models import (AssignmentRequest,
+                                                    Employee, EmployeeEmail,
+                                                    Layout, Organization, Pool,
+                                                    Rule, ShareableBooking)
 from rest_api.rest_api_server.utils import Config
-
-from optscale_client.auth_client.client_v2 import Client as AuthClient
-from optscale_client.herald_client.client_v2 import Client as HeraldClient
-from currency_symbols.currency_symbols import CURRENCY_SYMBOLS_MAP
+from tools.optscale_exceptions.common_exc import (ConflictException,
+                                                  ForbiddenException,
+                                                  NotFoundException,
+                                                  UnauthorizedException,
+                                                  WrongArgumentsException)
 
 LOG = logging.getLogger(__name__)
 
@@ -174,6 +177,7 @@ class EmployeeController(BaseController, MongoMixin):
         if org is None:
             raise NotFoundException(
                 Err.OE0002, [Organization.__name__, organization_id])
+        # TODO: Paginate
         return super().list(organization_id=org.id, **kwargs)
 
     def list(self, organization_id, last_login=False, **kwargs):

--- a/rest_api/rest_api_server/server.py
+++ b/rest_api/rest_api_server/server.py
@@ -1,21 +1,20 @@
-import os
-import logging
 import argparse
+import logging
+import os
 import tarfile
+
 import tornado.ioloop
-import pydevd_pycharm
 from etcd import Lock as EtcdLock
 from tornado.web import RedirectHandler
 
 import optscale_client.config_client.client
-
 import rest_api.rest_api_server.handlers.v1 as h_v1
 import rest_api.rest_api_server.handlers.v2 as h_v2
 from rest_api.rest_api_server.constants import urls_v2
 from rest_api.rest_api_server.handlers.v1.base import DefaultHandler
-from rest_api.rest_api_server.models.db_factory import DBType, DBFactory
-from rest_api.rest_api_server.handlers.v1.swagger import SwaggerStaticFileHandler
-
+from rest_api.rest_api_server.handlers.v1.swagger import \
+    SwaggerStaticFileHandler
+from rest_api.rest_api_server.models.db_factory import DBFactory, DBType
 
 DEFAULT_PORT = 8999
 DEFAULT_ETCD_HOST = 'etcd'
@@ -594,6 +593,11 @@ def make_app(db_type, etcd_host, etcd_port, wait=False):
 
 def main():
     if os.environ.get('PYCHARM_DEBUG_HOST'):
+        # NOTE: Intentionally importing it here as the module applies logic
+        #       on import time which breaks the built-in python debugger (pdb) 
+        
+        import pydevd_pycharm
+  
         pydevd_pycharm.settrace(
             host=os.environ['PYCHARM_DEBUG_HOST'],
             port=int(os.environ.get('PYCHARM_DEBUG_PORT', 3000)),


### PR DESCRIPTION
## Description

Improve the cloud account pagination to work with python filters. Let's first discuss the implementation and see if there are any flaws -- if we're happy I'll apply it to the employees endpoint (and others if needed).

I initially tried to do it all at once since the implementation is generic enough but this proved to be trickier than I thought -- I fix one thing and another breaks, so decided to draw the line here for the initial review and not waste too much time in case it doesn't work

## Related issue number

MPT-8485

## Checklist

* [x] The pull request title is a good summary of the changes
* [x] Unit tests for the changes exist
* [x] New and existing unit tests pass locally