### PR TITLE
Update invitation and resources e2e tests for stability

### DIFF
--- a/e2etests/tests/invitation-flow-tests.spec.ts
+++ b/e2etests/tests/invitation-flow-tests.spec.ts
@@ -213,7 +213,7 @@ test.describe("MPT-8230 Invitation Flow Tests for new users", {tag: ["@invitatio
     });
 });
 
-test.describe("MPT-8229 Validate invitations in the settings", {tag: ["@invitation-flow", "@ui", "@slow"]},  () => {
+test.describe("MPT-8229 Validate invitations in the settings", {tag: ["@invitation-flow", "@ui", "@slow"]}, () => {
     test.skip(process.env.USE_LIVE_DEMO === 'true', "Live demo environment does not support invitation flow tests");
 
     test("[229868] Invitation is visible in Settings Tab @slow", async ({
@@ -289,7 +289,7 @@ test.describe("MPT-8229 Validate invitations in the settings", {tag: ["@invitati
         });
 
         await test.step("Invite a existing user to the organisation", async () => {
-            await usersInvitePage.inviteUser(invitationEmail, 'Engineer', 'Marketplace (Dev)');
+            await usersInvitePage.inviteUser(invitationEmail, 'Engineer', 'AWS SWO');
             await usersInvitePage.userInvitedAlert.waitFor();
             await usersInvitePage.userInvitedAlertCloseButton.click();
         });
@@ -300,12 +300,13 @@ test.describe("MPT-8229 Validate invitations in the settings", {tag: ["@invitati
 
         await test.step("Login as new user", async () => {
             await loginPage.loginWithoutNavigation(invitationEmail, process.env.DEFAULT_USER_PASSWORD);
+            await loginPage.waitForPageLoaderToDisappear();
         });
 
         await test.step("View invitation in Settings", async () => {
             await settingsPage.navigateToURL();
             await settingsPage.clickInvitationsTab();
-            await expect(settingsPage.page.getByText('● Engineer at Marketplace (Dev)')).toBeVisible();
+            await expect(settingsPage.page.getByText('● Engineer at AWS SWO')).toBeVisible();
         });
     });
 });
@@ -334,6 +335,8 @@ test.describe("MPT-8231 Invitation Flow Tests for an existing user", {tag: ["@in
             emailVerificationLink = `${process.env.BASE_URL}/email-verification?email=${encodeURIComponent(invitationEmail)}&code=${verificationCode}`;
 
             await loginPage.login(process.env.DEFAULT_USER_EMAIL, process.env.DEFAULT_USER_PASSWORD);
+            await loginPage.waitForLoadingPageImgToDisappear();
+            await loginPage.waitForPageLoaderToDisappear();
         });
 
         await test.step("Navigate to the invitation page", async () => {
@@ -373,6 +376,7 @@ test.describe("MPT-8231 Invitation Flow Tests for an existing user", {tag: ["@in
 
         await test.step("Log back in as admin", async () => {
             await loginPage.loginWithoutNavigation(process.env.DEFAULT_USER_EMAIL, process.env.DEFAULT_USER_PASSWORD);
+            await loginPage.waitForPageLoaderToDisappear();
         })
         await test.step("Navigate to the invitation page", async () => {
             await mainMenu.clickUserManagement();
@@ -380,7 +384,7 @@ test.describe("MPT-8231 Invitation Flow Tests for an existing user", {tag: ["@in
         });
 
         await test.step("Invite a existing user to the organisation", async () => {
-            await usersInvitePage.inviteUser(invitationEmail, 'Manager', 'Marketplace (Dev)');
+            await usersInvitePage.inviteUser(invitationEmail, 'Manager', 'AWS SWO');
             await usersInvitePage.userInvitedAlert.waitFor();
             await usersInvitePage.userInvitedAlertCloseButton.click();
         });
@@ -396,7 +400,7 @@ test.describe("MPT-8231 Invitation Flow Tests for an existing user", {tag: ["@in
         await test.step("View invitation in Settings", async () => {
             await settingsPage.navigateToURL();
             await settingsPage.clickInvitationsTab();
-            await expect(settingsPage.page.getByText('● Manager at Marketplace (Dev) pool')).toBeVisible();
+            await expect(settingsPage.page.getByText('● Manager at AWS SWO pool')).toBeVisible();
         });
     });
 });

--- a/e2etests/tests/resources-tests.spec.ts
+++ b/e2etests/tests/resources-tests.spec.ts
@@ -50,10 +50,14 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
             await resourcesPage.waitForCanvas();
             if (await resourcesPage.resetFiltersBtn.isVisible()) await resourcesPage.resetFilters();
             await resourcesPage.waitForPageLoad();
+            await resourcesPage.firstResourceItemInTable.waitFor();
         });
     });
 
-    test("[230776] Possible savings matches those on recommendations page", async ({resourcesPage, recommendationsPage}) => {
+    test("[230776] Possible savings matches those on recommendations page", async ({
+                                                                                       resourcesPage,
+                                                                                       recommendationsPage
+                                                                                   }) => {
         let resourcesSavings: number;
         let recommendationsSavings: number;
 
@@ -259,7 +263,6 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
                     resp.url().includes('/breakdown_expenses')
                 ),
                 resourcesPage.selectLast7DaysDateRange(),
-                resourcesPage.waitForPageLoad()
             ]);
 
             expensesData = await expensesResponse.json();
@@ -501,7 +504,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
         await test.step('Validate owner breakdown structure for each day', async () => {
             const breakdown = ownerExpensesData.breakdown;
             const responseDates = Object.keys(breakdown).map(Number);
-            const expectedDates = Array.from({ length: 7 }, (_, i) => startDate + i * 86400);
+            const expectedDates = Array.from({length: 7}, (_, i) => startDate + i * 86400);
             expect.soft(responseDates.sort()).toEqual(expectedDates.sort());
 
             for (const [_day, ownerMap] of Object.entries(breakdown)) {
@@ -546,7 +549,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
         await test.step('Validate pool breakdown structure for each day', async () => {
             const breakdown = poolExpensesData.breakdown;
             const responseDates = Object.keys(breakdown).map(Number);
-            const expectedDates = Array.from({ length: 7 }, (_, i) => startDate + i * 86400);
+            const expectedDates = Array.from({length: 7}, (_, i) => startDate + i * 86400);
             expect.soft(responseDates.sort()).toEqual(expectedDates.sort());
 
             for (const [_day, poolMap] of Object.entries(breakdown)) {
@@ -590,7 +593,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
         await test.step('Validate K8s Node breakdown structure for each day', async () => {
             const breakdown = k8sNodeExpensesData.breakdown;
             const responseDates = Object.keys(breakdown).map(Number);
-            const expectedDates = Array.from({ length: 7 }, (_, i) => startDate + i * 86400);
+            const expectedDates = Array.from({length: 7}, (_, i) => startDate + i * 86400);
             expect.soft(responseDates.sort()).toEqual(expectedDates.sort());
 
             for (const [_day, nodeMap] of Object.entries(breakdown)) {
@@ -675,7 +678,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
         await test.step('Validate K8s service breakdown structure for each day', async () => {
             const breakdown = k8sServiceExpensesData.breakdown;
             const responseDates = Object.keys(breakdown).map(Number);
-            const expectedDates = Array.from({ length: 7 }, (_, i) => startDate + i * 86400);
+            const expectedDates = Array.from({length: 7}, (_, i) => startDate + i * 86400);
             expect.soft(responseDates.sort()).toEqual(expectedDates.sort());
 
             for (const [_day, serviceMap] of Object.entries(breakdown)) {


### PR DESCRIPTION
## Description

Adjusted invitation flow tests to use 'AWS SWO' instead of 'Marketplace (Dev)' and added waits for page loaders to improve reliability. In resources tests, improved date array formatting, added waits for resource items, and cleaned up unnecessary waits to enhance test stability and readability.

## Related issue number

https://softwareone.atlassian.net/browse/MPT-11958
