### PR TITLE
Fix/MPT 13763 toggle fixed time in restore session

### DIFF
--- a/e2etests/fixtures/page.fixture.ts
+++ b/e2etests/fixtures/page.fixture.ts
@@ -1,14 +1,15 @@
-import {test as base, type Page} from '@playwright/test';
+import { test as base, type Page } from '@playwright/test';
 import * as Pages from '../pages';
-import {LiveDemoService} from '../utils/auth-session-storage/auth-helpers';
-import {restoreUserSessionInLocalForage} from "../utils/auth-session-storage/localforage-service";
-import {BaseRequest} from "../utils/api-requests/base-request";
-import {apiInterceptors} from "../utils/api-requests/interceptor";
-import {InterceptionEntry} from "../types/interceptor.types";
+import { LiveDemoService } from '../utils/auth-session-storage/auth-helpers';
+import { restoreUserSessionInLocalForage } from "../utils/auth-session-storage/localforage-service";
+import { BaseRequest } from "../utils/api-requests/base-request";
+import { apiInterceptors } from "../utils/api-requests/interceptor";
+import { InterceptionEntry } from "../types/interceptor.types";
 
 interface Options {
   baseRequest: BaseRequest;
   restoreSession?: boolean;
+  setFixedTime?: boolean;
   interceptAPI?: { //List array must be wrapped as object first otherwise it will pass only first array item
     entries: InterceptionEntry[];
   }
@@ -20,7 +21,7 @@ type PageObjectCtor<T = unknown> = new (page: Page) => T;
 // Build a single fixture from a Page Object constructor
 const createFixture =
   <T>(Ctor: PageObjectCtor<T>) =>
-    async ({page}: { page: Page }, use: (po: T) => Promise<void>) => {
+    async ({ page }: { page: Page }, use: (po: T) => Promise<void>) => {
       await use(new Ctor(page));
     };
 
@@ -79,19 +80,26 @@ function buildFixtures<C extends Record<string, PageObjectCtor>>(ctors: C) {
 const fixtures = buildFixtures(constructors);
 
 export const test = base.extend<Fixtures & Options>({
-  restoreSession: [false, {option: true}],
-  interceptAPI: {entries: []}, // default empty list, can be overridden per test
+  restoreSession: [false, { option: true }],
+  setFixedTime: [false, { option: true }],
+  interceptAPI: { entries: [] }, // default empty list, can be overridden per test
 
 
-  page: async ({page, restoreSession, interceptAPI}, use) => {
+  page: async ({ page, restoreSession, setFixedTime, interceptAPI }, use) => {
     let verifyInterceptions: (() => void) | undefined;
     if (restoreSession) {
-      await restoreUserSessionInLocalForage(page, true);
+      await restoreUserSessionInLocalForage(page, setFixedTime);
     }
     if (interceptAPI.entries.length > 0) {
       verifyInterceptions = await apiInterceptors(page, interceptAPI.entries);
     }
-
+    if (process.env.BROWSER_ERROR_LOGGING === 'true') {
+      page.on('console', msg => {
+        if (msg.type() === 'error') {
+          console.error(`[Browser Console Error] ${msg.text()}`);
+        }
+      });
+    }
     await use(page);
 
     if (verifyInterceptions) {
@@ -99,11 +107,11 @@ export const test = base.extend<Fixtures & Options>({
     }
   },
 
-  baseRequest: async ({request}, use) => {
+  baseRequest: async ({ request }, use) => {
     await use(new BaseRequest(request));
   },
 
-  storageState: async ({}, use) => {
+  storageState: async ({ }, use) => {
     await use(LiveDemoService.getDefaultUserStorageState());
   },
   ...fixtures,

--- a/e2etests/regression-tests/tests/cloud-accounts.spec.ts
+++ b/e2etests/regression-tests/tests/cloud-accounts.spec.ts
@@ -1,22 +1,22 @@
-import {test} from "../../fixtures/page.fixture";
-import {expect} from "@playwright/test";
-import {roundElementDimensions} from "../utils/roundElementDimensions";
-import {DataSourcesMock} from "../mocks/cloud-accounts.mocks";
-import {InterceptionEntry} from "../../types/interceptor.types";
+import { test } from "../../fixtures/page.fixture";
+import { expect } from "@playwright/test";
+import { roundElementDimensions } from "../utils/roundElementDimensions";
+import { DataSourcesMock } from "../mocks/cloud-accounts.mocks";
+import { InterceptionEntry } from "../../types/interceptor.types";
 
 
 test.describe('FFC: Cloud Account @swo_regression', () => {
 
   const interceptorList: InterceptionEntry[] = [
-    {mock: DataSourcesMock, gql: "DataSources"}
+    { mock: DataSourcesMock, gql: "DataSources" }
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: interceptorList}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: interceptorList } });
 
   test('Page matches screenshots', async ({
-                                                          cloudAccountsPage,
-                                                          cloudAccountsConnectPage
-                                                        }) => {
+    cloudAccountsPage,
+    cloudAccountsConnectPage
+  }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
 
     await test.step('Navigate to Cloud Accounts page', async () => {

--- a/e2etests/regression-tests/tests/common-ui.spec.ts
+++ b/e2etests/regression-tests/tests/common-ui.spec.ts
@@ -1,12 +1,12 @@
-import {test} from "../../fixtures/page.fixture";
-import {expect} from "@playwright/test";
-import {roundElementDimensions} from "../utils/roundElementDimensions";
+import { test } from "../../fixtures/page.fixture";
+import { expect } from "@playwright/test";
+import { roundElementDimensions } from "../utils/roundElementDimensions";
 
 test.describe('FFC: Common UI @swo_regression', () => {
 
-  test.use({restoreSession: true});
+  test.use({ restoreSession: true, setFixedTime: true });
 
-  test("Header and Main Menu matches screenshots", async ({homePage, header, mainMenu}) => {
+  test("Header and Main Menu matches screenshots", async ({ homePage, header, mainMenu }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await homePage.navigateToURL();

--- a/e2etests/regression-tests/tests/events.spec.ts
+++ b/e2etests/regression-tests/tests/events.spec.ts
@@ -1,15 +1,15 @@
-import {test} from "../../fixtures/page.fixture";
-import {expect} from "@playwright/test";
-import {roundElementDimensions} from "../utils/roundElementDimensions";
-import {InterceptionEntry} from "../../types/interceptor.types";
-import {EventsRegressionResponse} from "../mocks/events.mocks";
+import { test } from "../../fixtures/page.fixture";
+import { expect } from "@playwright/test";
+import { roundElementDimensions } from "../utils/roundElementDimensions";
+import { InterceptionEntry } from "../../types/interceptor.types";
+import { EventsRegressionResponse } from "../mocks/events.mocks";
 
 test.describe('FFC: Events @swo_regression', () => {
-  const apiInterceptions: InterceptionEntry[] = [{mock: EventsRegressionResponse, gql: "events"}];
+  const apiInterceptions: InterceptionEntry[] = [{ mock: EventsRegressionResponse, gql: "events" }];
 
-  test.use({restoreSession: true, interceptAPI: {entries: apiInterceptions}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: apiInterceptions } });
 
-  test('Page matches screenshots', async ({eventsPage}) => {
+  test('Page matches screenshots', async ({ eventsPage }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
 
     await test.step('Navigate to Events page', async () => {

--- a/e2etests/regression-tests/tests/expenses.spec.ts
+++ b/e2etests/regression-tests/tests/expenses.spec.ts
@@ -1,7 +1,7 @@
-import {test} from "../../fixtures/page.fixture";
-import {expect} from "@playwright/test";
-import {roundElementDimensions} from "../utils/roundElementDimensions";
-import {InterceptionEntry} from "../../types/interceptor.types";
+import { test } from "../../fixtures/page.fixture";
+import { expect } from "@playwright/test";
+import { roundElementDimensions } from "../utils/roundElementDimensions";
+import { InterceptionEntry } from "../../types/interceptor.types";
 import {
   PoolsExpensesOwnerRegressionResponse,
   PoolsExpensesPoolRegressionResponse, PoolsExpensesRegressionResponse,
@@ -17,9 +17,9 @@ test.describe('FFC: Expenses Dashboard page @swo_regression', () => {
     }
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: apiInterceptions}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: apiInterceptions } });
 
-  test('Page matches screenshots', async ({expensesPage}) => {
+  test('Page matches screenshots', async ({ expensesPage }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
 
     await test.step('Navigate to Expenses page', async () => {
@@ -57,12 +57,12 @@ test.describe('FFC: Expenses Dashboard page @swo_regression', () => {
 
 test.describe('FFC: Expenses Map page @swo_regression', () => {
   const apiInterceptions: InterceptionEntry[] = [
-    {url: `/v2/organizations/[^/]+/region_expenses?.*$`, mock: RegionExpensesRegressionResponse},
+    { url: `/v2/organizations/[^/]+/region_expenses?.*$`, mock: RegionExpensesRegressionResponse },
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: apiInterceptions}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: apiInterceptions } });
 
-  test("Page matches screenshots", async ({expensesMapPage}) => {
+  test("Page matches screenshots", async ({ expensesMapPage }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await expensesMapPage.navigateToURL();
     await expensesMapPage.heading.hover();
@@ -74,18 +74,18 @@ test.describe('FFC: Expenses Map page @swo_regression', () => {
 
 test.describe('FFC: Expenses Breakdowns page @swo_regression', () => {
   const apiInterceptions: InterceptionEntry[] = [
-    {url: `/v2/pools_expenses/[^/]+filter_by=cloud`, mock: PoolsExpensesSourceRegressionResponse},
-    {url: `/v2/pools_expenses/[^/]+filter_by=pool`, mock: PoolsExpensesPoolRegressionResponse},
-    {url: `/v2/pools_expenses/[^/]+filter_by=employee`, mock: PoolsExpensesOwnerRegressionResponse},
+    { url: `/v2/pools_expenses/[^/]+filter_by=cloud`, mock: PoolsExpensesSourceRegressionResponse },
+    { url: `/v2/pools_expenses/[^/]+filter_by=pool`, mock: PoolsExpensesPoolRegressionResponse },
+    { url: `/v2/pools_expenses/[^/]+filter_by=employee`, mock: PoolsExpensesOwnerRegressionResponse },
     {
       url: `/v2/pools_expenses/[^/]+?end_date=[0-9]+&start_date=[0-9]+(?!.*filter)`,
       mock: PoolsExpensesRegressionResponse
     }
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: apiInterceptions}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: apiInterceptions } });
 
-  test('Page matches screenshots', async ({expensesPage}) => {
+  test('Page matches screenshots', async ({ expensesPage }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
 
     await test.step('Navigate to Expenses page', async () => {

--- a/e2etests/regression-tests/tests/homepage.spec.ts
+++ b/e2etests/regression-tests/tests/homepage.spec.ts
@@ -1,7 +1,7 @@
-import {test} from "../../fixtures/page.fixture";
-import {expect} from "@playwright/test";
-import {roundElementDimensions} from "../utils/roundElementDimensions";
-import {InterceptionEntry} from "../../types/interceptor.types";
+import { test } from "../../fixtures/page.fixture";
+import { expect } from "@playwright/test";
+import { roundElementDimensions } from "../utils/roundElementDimensions";
+import { InterceptionEntry } from "../../types/interceptor.types";
 import {
   AllowedActionsMock,
   HomeDataSourcesMock, OptimizationsMock,
@@ -12,21 +12,21 @@ import {
 test.describe('FFC: Home @swo_regression', () => {
 
   const apiInterceptions: InterceptionEntry[] = [
-    {gql: 'DataSources', mock: HomeDataSourcesMock},
-    {gql: 'CleanExpenses', mock: OrganizationCleanExpansesMock},
-    {url: `/v2/organizations/[^/]+/pool_expenses`, mock: OrganizationExpensesPoolsMock},
-    {url: `/v2/organizations/[^/]+/optimizations`, mock: OptimizationsMock},
-    {url: `/v2/allowed_actions`, mock: AllowedActionsMock},
-    {url: `/v2/pools/[^/]+?children=true&details=true`, mock: PoolsMock},
+    { gql: 'DataSources', mock: HomeDataSourcesMock },
+    { gql: 'CleanExpenses', mock: OrganizationCleanExpansesMock },
+    { url: `/v2/organizations/[^/]+/pool_expenses`, mock: OrganizationExpensesPoolsMock },
+    { url: `/v2/organizations/[^/]+/optimizations`, mock: OptimizationsMock },
+    { url: `/v2/allowed_actions`, mock: AllowedActionsMock },
+    { url: `/v2/pools/[^/]+?children=true&details=true`, mock: PoolsMock },
     {
       url: `/v2/organizations/[^/]+/organization_constraints\\?hit_days=3&type=resource_count_anomaly&type=expense_anomaly&type=resource_quota&type=recurring_budget&type=expiring_budget&type=tagging_policy`,
       mock: OrganizationConstraintsMock
     }
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: apiInterceptions}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: apiInterceptions } });
 
-  test('Blocks matches screenshots', async ({homePage}) => {
+  test('Blocks matches screenshots', async ({ homePage }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await homePage.navigateToURL();

--- a/e2etests/regression-tests/tests/policies.spec.ts
+++ b/e2etests/regression-tests/tests/policies.spec.ts
@@ -1,8 +1,8 @@
-import {test} from "../../fixtures/page.fixture";
-import {expect} from "@playwright/test";
-import {roundElementDimensions} from "../utils/roundElementDimensions";
-import {InterceptionEntry} from "../../types/interceptor.types";
-import {PolicyMock, TaggingPolicyMock, AnomaliesConstraintsMock} from "../mocks/policies.mocks";
+import { test } from "../../fixtures/page.fixture";
+import { expect } from "@playwright/test";
+import { roundElementDimensions } from "../utils/roundElementDimensions";
+import { InterceptionEntry } from "../../types/interceptor.types";
+import { PolicyMock, TaggingPolicyMock, AnomaliesConstraintsMock } from "../mocks/policies.mocks";
 
 test.describe('FFC: Anomalies page @swo_regression', () => {
 
@@ -13,9 +13,9 @@ test.describe('FFC: Anomalies page @swo_regression', () => {
     },
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: interceptorList}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: interceptorList } });
 
-  test('Page matches screenshots', async ({anomaliesPage, anomaliesCreatePage}) => {
+  test('Page matches screenshots', async ({ anomaliesPage, anomaliesCreatePage }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
 
     await test.step('Navigate to Anomalies page', async () => {
@@ -52,9 +52,9 @@ test.describe('FFC: Policies page @swo_regression', () => {
     },
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: apiInterceptions}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: apiInterceptions } });
 
-  test('Page matches screenshots', async ({policiesPage, policiesCreatePage}) => {
+  test('Page matches screenshots', async ({ policiesPage, policiesCreatePage }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
 
     await test.step('Navigate to Policies page', async () => {
@@ -92,12 +92,12 @@ test.describe('FFC: Tagging Policies page @swo_regression', () => {
     },
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: apiInterceptions}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: apiInterceptions } });
 
   test('Page matches screenshots', async ({
-                                            taggingPoliciesPage,
-                                            taggingPoliciesCreatePage
-                                          }) => {
+    taggingPoliciesPage,
+    taggingPoliciesCreatePage
+  }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
 
     await test.step('Navigate to Tagging Policies page', async () => {

--- a/e2etests/regression-tests/tests/pools.spec.ts
+++ b/e2etests/regression-tests/tests/pools.spec.ts
@@ -1,19 +1,19 @@
-import {test} from "../../fixtures/page.fixture";
-import {expect} from "@playwright/test";
-import {roundElementDimensions} from "../utils/roundElementDimensions";
-import {InterceptionEntry} from "../../types/interceptor.types";
-import {AllowedActionsPoolRegressionResponse, PoolRegressionResponse} from "../mocks/pools.mocks";
+import { test } from "../../fixtures/page.fixture";
+import { expect } from "@playwright/test";
+import { roundElementDimensions } from "../utils/roundElementDimensions";
+import { InterceptionEntry } from "../../types/interceptor.types";
+import { AllowedActionsPoolRegressionResponse, PoolRegressionResponse } from "../mocks/pools.mocks";
 
 test.describe('FFC: Pools @swo_regression', () => {
 
   const apiInterceptions: InterceptionEntry[] = [
-    {url: `/v2/pools/[^/]+?children=true&details=true`, mock: PoolRegressionResponse},
-    {url: `/v2/allowed_actions\\?pool=[^&]+.*`, mock: AllowedActionsPoolRegressionResponse},
+    { url: `/v2/pools/[^/]+?children=true&details=true`, mock: PoolRegressionResponse },
+    { url: `/v2/allowed_actions\\?pool=[^&]+.*`, mock: AllowedActionsPoolRegressionResponse },
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: apiInterceptions}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: apiInterceptions } });
 
-  test('Page matches screenshots', async ({poolsPage}) => {
+  test('Page matches screenshots', async ({ poolsPage }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
 
     await test.step('Navigate to Pools page', async () => {

--- a/e2etests/regression-tests/tests/recommendations.spec.ts
+++ b/e2etests/regression-tests/tests/recommendations.spec.ts
@@ -1,7 +1,7 @@
-import {test} from "../../fixtures/page.fixture";
-import {expect} from "@playwright/test";
-import {roundElementDimensions} from "../utils/roundElementDimensions";
-import {InterceptionEntry} from "../../types/interceptor.types";
+import { test } from "../../fixtures/page.fixture";
+import { expect } from "@playwright/test";
+import { roundElementDimensions } from "../utils/roundElementDimensions";
+import { InterceptionEntry } from "../../types/interceptor.types";
 import {
   GeminisMock,
   OptionsMock,
@@ -14,17 +14,17 @@ import {
 
 test.describe('FFC: Recommendations @swo_regression', () => {
   const apiInterceptions: InterceptionEntry[] = [
-    {url: `/v2/organizations/[^/]+/geminis`, mock: GeminisMock},
-    {url: `/v2/organizations/[^/]+/options`, mock: OptionsMock},
-    {url: `/v2/organizations/[^/]+/ri_breakdown`, mock: RIBreakdownMock},
-    {url: `/v2/organizations/[^/]+/sp_breakdown`, mock: SPBreakdownMock},
-    {url: `/v2/organizations/[^/]+/summary_expenses`, mock: SummaryExpensesMock},
-    {url: `/v2/organizations/[^/]+/optimizations`, mock: OptimisationsMock}
+    { url: `/v2/organizations/[^/]+/geminis`, mock: GeminisMock },
+    { url: `/v2/organizations/[^/]+/options`, mock: OptionsMock },
+    { url: `/v2/organizations/[^/]+/ri_breakdown`, mock: RIBreakdownMock },
+    { url: `/v2/organizations/[^/]+/sp_breakdown`, mock: SPBreakdownMock },
+    { url: `/v2/organizations/[^/]+/summary_expenses`, mock: SummaryExpensesMock },
+    { url: `/v2/organizations/[^/]+/optimizations`, mock: OptimisationsMock }
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: apiInterceptions}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: apiInterceptions } });
 
-  test('Page matches screenshots', async ({recommendationsPage}) => {
+  test('Page matches screenshots', async ({ recommendationsPage }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await recommendationsPage.navigateToURL();

--- a/e2etests/regression-tests/tests/resources.spec.ts
+++ b/e2etests/regression-tests/tests/resources.spec.ts
@@ -1,7 +1,7 @@
-import {test} from "../../fixtures/page.fixture";
-import {expect} from "@playwright/test";
-import {roundElementDimensions} from "../utils/roundElementDimensions";
-import {InterceptionEntry} from "../../types/interceptor.types";
+import { test } from "../../fixtures/page.fixture";
+import { expect } from "@playwright/test";
+import { roundElementDimensions } from "../utils/roundElementDimensions";
+import { InterceptionEntry } from "../../types/interceptor.types";
 
 import {
   BreakdownExpensesMock,
@@ -17,16 +17,16 @@ import {
 test.describe('FFC: Resources Dashboard @swo_regression', () => {
 
   const apiInterceptionsDashboard: InterceptionEntry[] = [
-    {url: `v2/organizations/[^/]+/summary_expenses`, mock: SummaryMock},
-    {url: `v2/organizations/[^/]+/breakdown_expenses`, mock: BreakdownExpensesMock},
-    {url: `v2/organizations/[^/]+/available_filters`, mock: ResourceAvailableFiltersMock},
-    {url: `v2/organizations/[^/]+/resources_count`, mock: ResourcesCountMock},
-    {url: `v2/organizations/[^/]+/breakdown_tags`, mock: BreakdownTagsMock},
+    { url: `v2/organizations/[^/]+/summary_expenses`, mock: SummaryMock },
+    { url: `v2/organizations/[^/]+/breakdown_expenses`, mock: BreakdownExpensesMock },
+    { url: `v2/organizations/[^/]+/available_filters`, mock: ResourceAvailableFiltersMock },
+    { url: `v2/organizations/[^/]+/resources_count`, mock: ResourcesCountMock },
+    { url: `v2/organizations/[^/]+/breakdown_tags`, mock: BreakdownTagsMock },
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: [...apiInterceptionsDashboard]}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: [...apiInterceptionsDashboard] } });
 
-  test('Page matches screenshots', async ({resourcesPage}) => {
+  test('Page matches screenshots', async ({ resourcesPage }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
     await test.step('Set up test data', async () => {
       await resourcesPage.navigateToURL();
@@ -76,24 +76,24 @@ test.describe('FFC: Resources Dashboard @swo_regression', () => {
 test.describe('FFC: Resources Details @swo_regression', () => {
 
   const apiInterceptionsDetails: InterceptionEntry[] = [
-    {url: `v2/organizations/[^/]+/summary_expenses`, mock: SummaryMock},
-    {url: `v2/organizations/[^/]+/breakdown_expenses`, mock: BreakdownExpensesMock},
-    {url: `v2/organizations/[^/]+/available_filters`, mock: ResourceAvailableFiltersMock},
-    {url: `v2/cloud_resources/[^/]+?details=true`, mock: ResourceDetailsMock},
-    {url: `v2/cloud_resources/[^/]+/limit_hits`, mock: LimitHitsMock},
-    {url: `v2/allowed_actions\\?cloud_resource=.+`, mock: AllowedActionsSunflowerEUMock},
-    {url: `v2/resources/[^/]+/raw_expenses`, mock: RawExpensesMock},
-    {url: `v2/organizations/[^/]+/summary_expenses`, mock: SummaryMock},
-    {url: `v2/organizations/[^/]+/breakdown_expenses`, mock: BreakdownExpensesMock},
-    {url: `v2/organizations/[^/]+/available_filters`, mock: ResourceAvailableFiltersMock},
+    { url: `v2/organizations/[^/]+/summary_expenses`, mock: SummaryMock },
+    { url: `v2/organizations/[^/]+/breakdown_expenses`, mock: BreakdownExpensesMock },
+    { url: `v2/organizations/[^/]+/available_filters`, mock: ResourceAvailableFiltersMock },
+    { url: `v2/cloud_resources/[^/]+?details=true`, mock: ResourceDetailsMock },
+    { url: `v2/cloud_resources/[^/]+/limit_hits`, mock: LimitHitsMock },
+    { url: `v2/allowed_actions\\?cloud_resource=.+`, mock: AllowedActionsSunflowerEUMock },
+    { url: `v2/resources/[^/]+/raw_expenses`, mock: RawExpensesMock },
+    { url: `v2/organizations/[^/]+/summary_expenses`, mock: SummaryMock },
+    { url: `v2/organizations/[^/]+/breakdown_expenses`, mock: BreakdownExpensesMock },
+    { url: `v2/organizations/[^/]+/available_filters`, mock: ResourceAvailableFiltersMock },
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: [...apiInterceptionsDetails]}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: [...apiInterceptionsDetails] } });
 
   test('Resource details page matches screenshots',
     async ({
-             resourcesPage, resourceDetailsPage
-           }) => {
+      resourcesPage, resourceDetailsPage
+    }) => {
 
       if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
       await test.step('Navigate to Resource details page for Sunflower EU Fra', async () => {

--- a/e2etests/regression-tests/tests/users.spec.ts
+++ b/e2etests/regression-tests/tests/users.spec.ts
@@ -1,19 +1,19 @@
-import {test} from "../../fixtures/page.fixture";
-import {expect} from "@playwright/test";
-import {roundElementDimensions} from "../utils/roundElementDimensions";
-import {InterceptionEntry} from "../../types/interceptor.types";
-import {EmployeesMock, UsersPoolsPermissionsMock} from "../mocks/user.mocks";
+import { test } from "../../fixtures/page.fixture";
+import { expect } from "@playwright/test";
+import { roundElementDimensions } from "../utils/roundElementDimensions";
+import { InterceptionEntry } from "../../types/interceptor.types";
+import { EmployeesMock, UsersPoolsPermissionsMock } from "../mocks/user.mocks";
 
 
 test.describe('FFC: Users @swo_regression', () => {
   const apiInterceptions: InterceptionEntry[] = [
-    {url: `/v2/organizations/[^/]+/employees`, mock: EmployeesMock},
-    {url: `/v2/organizations/[^/]+/pools\\?permission=INFO_ORGANIZATION`, mock: UsersPoolsPermissionsMock},
+    { url: `/v2/organizations/[^/]+/employees`, mock: EmployeesMock },
+    { url: `/v2/organizations/[^/]+/pools\\?permission=INFO_ORGANIZATION`, mock: UsersPoolsPermissionsMock },
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: apiInterceptions}});
+  test.use({ restoreSession: true, setFixedTime: true, interceptAPI: { entries: apiInterceptions } });
 
-  test('Users page matches screenshots', async ({usersPage, usersInvitePage}) => {
+  test('Users page matches screenshots', async ({ usersPage, usersInvitePage }) => {
     if (process.env.SCREENSHOT_UPDATE_DELAY) test.slow();
 
     await test.step('Navigate to Users page', async () => {

--- a/e2etests/tests/resources-tests.spec.ts
+++ b/e2etests/tests/resources-tests.spec.ts
@@ -1,6 +1,6 @@
-import {test} from "../fixtures/page.fixture";
-import {expect} from "@playwright/test";
-import {expectWithinDrift} from "../utils/custom-assertions";
+import { test } from "../fixtures/page.fixture";
+import { expect } from "@playwright/test";
+import { expectWithinDrift } from "../utils/custom-assertions";
 
 import {
   BreakdownExpensesByServiceResponse,
@@ -13,8 +13,8 @@ import {
   BreakdownExpensesByPoolResponse,
   BreakdownExpensesByK8sNodeResponse, BreakdownExpensesByK8sNamespaceResponse, BreakdownExpensesByK8sServiceResponse
 } from "../mocks/resources-page.mocks";
-import {comparePngImages} from "../utils/image-comparison";
-import {cleanUpDirectoryIfEnabled} from "../utils/test-after-all-utils";
+import { comparePngImages } from "../utils/image-comparison";
+import { cleanUpDirectoryIfEnabled } from "../utils/test-after-all-utils";
 import {
   getExpectedDateRangeText,
   getLast7DaysUnixRange,
@@ -31,17 +31,17 @@ import {
   ServiceNameResourceResponse,
   TagsResponse
 } from "../types/api-response.types";
-import {fetchBreakdownExpenses} from "../utils/api-helpers";
-import {InterceptionEntry} from "../types/interceptor.types";
+import { fetchBreakdownExpenses } from "../utils/api-helpers";
+import { InterceptionEntry } from "../types/interceptor.types";
 
 
-test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, () => {
+test.describe("[MPT-11957] Resources page tests", { tag: ["@ui", "@resources"] }, () => {
   test.skip(process.env.USE_LIVE_DEMO === 'true', "Live demo environment is not supported by these tests");
-  test.use({restoreSession: true});
+  test.use({ restoreSession: true });
   let totalExpensesValue: number;
   let itemisedTotal: number;
 
-  test.beforeEach('Login admin user', async ({page, resourcesPage}) => {
+  test.beforeEach('Login admin user', async ({ page, resourcesPage }) => {
     await test.step('Login admin user', async () => {
       await resourcesPage.navigateToURL();
       await resourcesPage.waitForPageLoaderToDisappear();
@@ -53,9 +53,9 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
   });
 
   test("[230776] Possible savings matches those on recommendations page", async ({
-                                                                                   resourcesPage,
-                                                                                   recommendationsPage
-                                                                                 }) => {
+    resourcesPage,
+    recommendationsPage
+  }) => {
     let resourcesSavings: number;
     let recommendationsSavings: number;
 
@@ -73,7 +73,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     });
   })
 
-  test("[230778] All expected filters are displayed", async ({resourcesPage}) => {
+  test("[230778] All expected filters are displayed", async ({ resourcesPage }) => {
     await test.step('Click Show more filters button', async () => {
       await resourcesPage.clickShowMoreFilters();
       await resourcesPage.showLessFiltersBtn.waitFor();
@@ -110,7 +110,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     });
   })
 
-  test("[230779] Verify table column selection", async ({resourcesPage}) => {
+  test("[230779] Verify table column selection", async ({ resourcesPage }) => {
     const defaultColumns = [
       resourcesPage.resourceTableHeading, resourcesPage.expensesTableHeading, resourcesPage.paidNetworkTrafficTableHeading,
       resourcesPage.metadataTableHeading, resourcesPage.poolOwnerTableHeading, resourcesPage.typeTableHeading, resourcesPage.tagsTableHeading
@@ -172,7 +172,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     });
   });
 
-  test("[230780] Unfiltered Total expenses matches table itemised total", {tag: '@slow'}, async ({resourcesPage}) => {
+  test("[230780] Unfiltered Total expenses matches table itemised total", { tag: '@slow' }, async ({ resourcesPage }) => {
     test.setTimeout(1200000);
 
     await test.step('Get total expenses value from resources page', async () => {
@@ -191,7 +191,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     });
   });
 
-  test("[230788] Filtered Total expenses matches table itemised total", {tag: '@slow'}, async ({resourcesPage}) => {
+  test("[230788] Filtered Total expenses matches table itemised total", { tag: '@slow' }, async ({ resourcesPage }) => {
     test.setTimeout(90000);
     let initialTotalExpensesValue: number;
 
@@ -229,10 +229,10 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     });
   });
 
-  test("[230781] Total expenses matches table itemised total for date range set to last 7 days", {tag: '@slow'}, async ({
-                                                                                                                          resourcesPage,
-                                                                                                                          datePicker
-                                                                                                                        }) => {
+  test("[230781] Total expenses matches table itemised total for date range set to last 7 days", { tag: '@slow' }, async ({
+    resourcesPage,
+    datePicker
+  }) => {
     test.setTimeout(90000);
 
     await test.step('Get total expenses value for last 7 days', async () => {
@@ -254,8 +254,8 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     });
   });
 
-  test('[230782] Validate API default chart/table data for 7 days', async ({resourcesPage, datePicker}) => {
-    const {startDate, endDate} = getLast7DaysUnixRange();
+  test('[230782] Validate API default chart/table data for 7 days', async ({ resourcesPage, datePicker }) => {
+    const { startDate, endDate } = getLast7DaysUnixRange();
 
     let expensesData: ServiceNameExpensesResponse;
     await test.step('Load expenses data for the last 7 days', async () => {
@@ -277,7 +277,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     });
 
     await test.step('Validate expenses breakdown covers correct 7-day range', async () => {
-      const expectedDates = Array.from({length: 7}, (_, i) => startDate + i * 86400);
+      const expectedDates = Array.from({ length: 7 }, (_, i) => startDate + i * 86400);
       const responseDates = Object.keys(expensesData.breakdown).map(Number);
       expect.soft(responseDates.sort()).toEqual(expectedDates.sort());
     });
@@ -338,12 +338,12 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     });
   });
 
-  test('[230783] Validate API data for the daily expenses chart by breakdown for 7 days', {tag: '@slow'}, async ({
-                                                                                                                   resourcesPage,
-                                                                                                                   datePicker
-                                                                                                                 }) => {
+  test('[230783] Validate API data for the daily expenses chart by breakdown for 7 days', { tag: '@slow' }, async ({
+    resourcesPage,
+    datePicker
+  }) => {
     test.setTimeout(90000);
-    const {startDate, endDate} = getLast7DaysUnixRange();
+    const { startDate, endDate } = getLast7DaysUnixRange();
 
     await test.step('Set last 7 days date range', async () => {
       await datePicker.selectLast7DaysDateRange();
@@ -372,7 +372,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
       const breakdownDays = Object.keys(regionExpensesData.breakdown);
       expect.soft(breakdownDays.length).toBe(7);
 
-      const expectedDays = Array.from({length: 7}, (_, i) => (startDate + i * 86400).toString());
+      const expectedDays = Array.from({ length: 7 }, (_, i) => (startDate + i * 86400).toString());
       expect.soft(breakdownDays.sort()).toEqual(expectedDays.sort());
     });
 
@@ -417,7 +417,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     await test.step('Validate resource type daily breakdown structure', async () => {
       const breakdown = resourceTypeExpensesData.breakdown;
       const responseDates = Object.keys(breakdown).map(Number);
-      const expectedDates = Array.from({length: 7}, (_, i) => startDate + i * 86400);
+      const expectedDates = Array.from({ length: 7 }, (_, i) => startDate + i * 86400);
       expect.soft(responseDates.sort()).toEqual(expectedDates.sort());
 
       for (const [_day, typeMap] of Object.entries(breakdown)) {
@@ -461,7 +461,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     await test.step('Validate data source breakdown structure for each day', async () => {
       const breakdown = dataSourceExpensesData.breakdown;
       const responseDates = Object.keys(breakdown).map(Number);
-      const expectedDates = Array.from({length: 7}, (_, i) => startDate + i * 86400);
+      const expectedDates = Array.from({ length: 7 }, (_, i) => startDate + i * 86400);
       expect.soft(responseDates.sort()).toEqual(expectedDates.sort());
 
       for (const [_day, sourceMap] of Object.entries(breakdown)) {
@@ -507,7 +507,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     await test.step('Validate owner breakdown structure for each day', async () => {
       const breakdown = ownerExpensesData.breakdown;
       const responseDates = Object.keys(breakdown).map(Number);
-      const expectedDates = Array.from({length: 7}, (_, i) => startDate + i * 86400);
+      const expectedDates = Array.from({ length: 7 }, (_, i) => startDate + i * 86400);
       expect.soft(responseDates.sort()).toEqual(expectedDates.sort());
 
       for (const [_day, ownerMap] of Object.entries(breakdown)) {
@@ -552,7 +552,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     await test.step('Validate pool breakdown structure for each day', async () => {
       const breakdown = poolExpensesData.breakdown;
       const responseDates = Object.keys(breakdown).map(Number);
-      const expectedDates = Array.from({length: 7}, (_, i) => startDate + i * 86400);
+      const expectedDates = Array.from({ length: 7 }, (_, i) => startDate + i * 86400);
       expect.soft(responseDates.sort()).toEqual(expectedDates.sort());
 
       for (const [_day, poolMap] of Object.entries(breakdown)) {
@@ -596,7 +596,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     await test.step('Validate K8s Node breakdown structure for each day', async () => {
       const breakdown = k8sNodeExpensesData.breakdown;
       const responseDates = Object.keys(breakdown).map(Number);
-      const expectedDates = Array.from({length: 7}, (_, i) => startDate + i * 86400);
+      const expectedDates = Array.from({ length: 7 }, (_, i) => startDate + i * 86400);
       expect.soft(responseDates.sort()).toEqual(expectedDates.sort());
 
       for (const [_day, nodeMap] of Object.entries(breakdown)) {
@@ -639,7 +639,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     await test.step('Validate K8s namespace breakdown structure for each day', async () => {
       const breakdown = k8sNamespaceExpensesData.breakdown;
       const responseDates = Object.keys(breakdown).map(Number);
-      const expectedDates = Array.from({length: 7}, (_, i) => startDate + i * 86400);
+      const expectedDates = Array.from({ length: 7 }, (_, i) => startDate + i * 86400);
       expect.soft(responseDates.sort()).toEqual(expectedDates.sort());
 
       for (const [_day, namespaceMap] of Object.entries(breakdown)) {
@@ -681,7 +681,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
     await test.step('Validate K8s service breakdown structure for each day', async () => {
       const breakdown = k8sServiceExpensesData.breakdown;
       const responseDates = Object.keys(breakdown).map(Number);
-      const expectedDates = Array.from({length: 7}, (_, i) => startDate + i * 86400);
+      const expectedDates = Array.from({ length: 7 }, (_, i) => startDate + i * 86400);
       expect.soft(responseDates.sort()).toEqual(expectedDates.sort());
 
       for (const [_day, serviceMap] of Object.entries(breakdown)) {
@@ -694,7 +694,7 @@ test.describe("[MPT-11957] Resources page tests", {tag: ["@ui", "@resources"]}, 
   });
 })
 
-test.describe("[MPT-11957] Resources page mocked tests", {tag: ["@ui", "@resources"]}, () => {
+test.describe("[MPT-11957] Resources page mocked tests", { tag: ["@ui", "@resources"] }, () => {
   test.skip(process.env.USE_LIVE_DEMO === 'true', "Live demo environment is not supported by these tests");
 
 
@@ -745,9 +745,9 @@ test.describe("[MPT-11957] Resources page mocked tests", {tag: ["@ui", "@resourc
     }
   ];
 
-  test.use({restoreSession: true, interceptAPI: {entries: apiInterceptions}});
+  test.use({ restoreSession: true, interceptAPI: { entries: apiInterceptions } });
 
-  test.beforeEach('Login admin user', async ({ resourcesPage}) => {
+  test.beforeEach('Login admin user', async ({ resourcesPage }) => {
     await test.step('Login admin user', async () => {
       await resourcesPage.page.clock.setFixedTime(new Date('2025-07-15T14:40:00Z'));
       await resourcesPage.navigateToURL('/resources');
@@ -759,7 +759,7 @@ test.describe("[MPT-11957] Resources page mocked tests", {tag: ["@ui", "@resourc
     });
   });
 
-  test('[230784] Verify default service daily expenses chart export with and without legend', {tag: "@p1"}, async ({resourcesPage}) => {
+  test('[230784] Verify default service daily expenses chart export with and without legend', { tag: "@p1" }, async ({ resourcesPage }) => {
     let actualPath = 'tests/downloads/expenses-chart-export.png';
     let expectedPath = 'tests/expected/expected-expenses-chart-export.png';
     let diffPath = 'tests/downloads/diff-expenses-chart-export.png';
@@ -789,7 +789,7 @@ test.describe("[MPT-11957] Resources page mocked tests", {tag: ["@ui", "@resourc
     });
   });
 
-  test('[230785] Verify weekly and monthly expenses chart export', async ({resourcesPage}) => {
+  test('[230785] Verify weekly and monthly expenses chart export', async ({ resourcesPage }) => {
     let actualPath = 'tests/downloads/weekly-expenses-chart-export.png';
     let expectedPath = 'tests/expected/expected-weekly-expenses-chart-export.png';
     let diffPath = 'tests/downloads/diff-weekly-expenses-chart-export.png';
@@ -814,7 +814,7 @@ test.describe("[MPT-11957] Resources page mocked tests", {tag: ["@ui", "@resourc
     });
   })
 
-  test('[230786] Verify expenses chart export with different categories', async ({resourcesPage}) => {
+  test('[230786] Verify expenses chart export with different categories', async ({ resourcesPage }) => {
     let actualPath = 'tests/downloads/region-expenses-chart-export.png';
     let expectedPath = 'tests/expected/expected-region-expenses-chart-export.png';
     let diffPath = 'tests/downloads/diff-region-expenses-chart-export.png';
@@ -905,7 +905,7 @@ test.describe("[MPT-11957] Resources page mocked tests", {tag: ["@ui", "@resourc
     });
   });
 
-  test("[230787] Verify table grouping", async ({resourcesPage}) => {
+  test("[230787] Verify table grouping", async ({ resourcesPage }) => {
     await test.step('Verify default grouping is None', async () => {
       await resourcesPage.table.waitFor();
       await resourcesPage.table.scrollIntoViewIfNeeded();


### PR DESCRIPTION

## Description
Introduces a setFixedTime option to the Playwright test fixture and applies it only to all regression tests. This ensures tests run with a fixed time context, improving consistency and reliability of screenshot and data-based assertions, without breaking E2E tests that use current or different times. Returned Browser console error logging that got lost.

## Related issue number

https://softwareone.atlassian.net/browse/MPT-13763

