### PR TITLE
Enhance API interception and cloud account link handling

### DIFF
--- a/e2etests/pages/cloud-accounts-page.ts
+++ b/e2etests/pages/cloud-accounts-page.ts
@@ -7,49 +7,79 @@ import {debugLog} from "../utils/debug-logging";
  * Extends the BasePage class.
  */
 export class CloudAccountsPage extends BasePage {
-  readonly heading: Locator;
-  readonly addBtn: Locator;
-  readonly advancedTabBtn: Locator;
-  readonly lastBillingImportStatus: Locator;
-  readonly billingStatusCompletedIcon: Locator;
-  readonly table: Locator;
-  readonly allCloudAccountLinks: Locator;
+    readonly heading: Locator;
+    readonly addBtn: Locator;
+    readonly advancedTabBtn: Locator;
+    readonly lastBillingImportStatus: Locator;
+    readonly billingStatusCompletedIcon: Locator;
+    readonly table: Locator;
+    readonly allCloudAccountLinks: Locator;
 
-  /**
-   * Initializes a new instance of the CloudAccountsPage class.
-   * @param {Page} page - The Playwright page object.
-   */
-  constructor(page: Page) {
-    super(page, '/cloud-accounts');
-    this.heading = this.main.locator('//h1[.="Data sources"]');
-    this.table = this.main.locator('//table');
-    this.advancedTabBtn = this.main.getByTestId('tab_advanced');
-    this.lastBillingImportStatus = this.main.getByTestId('value_last_billing_report_status');
-    this.billingStatusCompletedIcon = this.getByAnyTestId('CheckCircleIcon', this.lastBillingImportStatus);
-    this.addBtn = this.main.getByTestId('btn_add');
-    this.allCloudAccountLinks = this.table.locator('//td//a');
-  }
+    /**
+     * Initializes a new instance of the CloudAccountsPage class.
+     * @param {Page} page - The Playwright page object.
+     */
+    constructor(page: Page) {
+        super(page, '/cloud-accounts');
+        this.heading = this.main.locator('//h1[.="Data sources"]');
+        this.table = this.main.locator('//table');
+        this.advancedTabBtn = this.main.getByTestId('tab_advanced');
+        this.lastBillingImportStatus = this.main.getByTestId('value_last_billing_report_status');
+        this.billingStatusCompletedIcon = this.getByAnyTestId('CheckCircleIcon', this.lastBillingImportStatus);
+        this.addBtn = this.main.getByTestId('btn_add');
+        this.allCloudAccountLinks = this.table.locator('xpath=(//td//a)');
+    }
 
-  /**
-   * Clicks the Add button on the Cloud Accounts page.
-   * @returns {Promise<void>}
-   */
-  async clickAddBtn(): Promise<void> {
-    await this.addBtn.click();
-  }
+    /**
+     * Clicks the Add button on the Cloud Accounts page.
+     * @returns {Promise<void>}
+     */
+    async clickAddBtn(): Promise<void> {
+        await this.addBtn.click();
+    }
 
-  async clickAdvancedTabBtn(): Promise<void> {
-    await this.advancedTabBtn.click();
-  }
+    /**
+     * Clicks the "Advanced" tab button on the Cloud Accounts page.
+     * @returns {Promise<void>} A promise that resolves when the action is complete.
+     */
+    async clickAdvancedTabBtn(): Promise<void> {
+        await this.advancedTabBtn.click();
+    }
 
-  async clickCloudAccountLinkByName(name: string): Promise<void> {
-      const locator = this.allCloudAccountLinks.filter({hasText: name});
-      debugLog(`Clicking on cloud account link with name: ${name}`);
-      return locator.click();
-  }
+    /**
+     * Clicks a cloud account link by its name.
+     * @param {string} name - The name of the cloud account link to click.
+     * @returns {Promise<void>} A promise that resolves when the action is complete.
+     */
+    async clickCloudAccountLinkByName(name: string): Promise<void> {
+        const locator = this.allCloudAccountLinks.filter({hasText: name});
+        debugLog(`Clicking on cloud account link with name: ${name}`);
+        return locator.click();
+    }
 
-  async clickCloudAccountLink(index = 1): Promise<void> {
-      debugLog(`Clicking on cloud account link at index: ${index} - ${await this.allCloudAccountLinks.nth(index - 1).textContent()}`);
-    return this.allCloudAccountLinks.nth(index - 1).click();
-  }
+    /**
+     * Clicks a cloud account link by its index in the list.
+     * If the link has an expand button, it clicks the expand button first and then clicks the nested link.
+     * @param {number} [index=1] - The index of the cloud account link to click (1-based).
+     * @returns {Promise<void>} A promise that resolves when the action is complete.
+     */
+    async clickCloudAccountLink(index = 1): Promise<void> {
+        const expandButton = this.allCloudAccountLinks.nth(index - 1).locator(`xpath=/../preceding-sibling::button/*[@data-testid="ExpandMoreIcon"]`);
+        await this.allCloudAccountLinks.nth(index - 1).waitFor();
+
+        const hasExpandButton = await expandButton.isVisible();
+        debugLog(`Cloud account link at index: ${index} has expand button: ${hasExpandButton}`);
+
+        if (hasExpandButton) {
+            await expandButton.click();
+            debugLog(`Clicking on expand cloud account link at index: ${index} - ${await this.allCloudAccountLinks.nth(index - 1).textContent()}`);
+            const firstLink = this.allCloudAccountLinks.nth(index - 1).locator('//ancestor::tr[1]/following-sibling::tr[1]//a');
+            debugLog(`Clicking on first nested cloud account link at index: ${index} - ${await firstLink.textContent()}`);
+            await firstLink.click();
+        } else {
+            debugLog(`Clicking on cloud account link at index: ${index} - ${await this.allCloudAccountLinks.nth(index - 1).textContent()}`);
+            return this.allCloudAccountLinks.nth(index - 1).click();
+        }
+    }
+
 }

--- a/e2etests/tests/cloud-accounts-tests.spec.ts
+++ b/e2etests/tests/cloud-accounts-tests.spec.ts
@@ -24,7 +24,7 @@ test.describe('Cloud Accounts Tests', {tag: ["@ui", "@cloudaccounts"]},() => {
         await test.step('Fetch Data Source Response for first account', async () => {
             const [response] = await Promise.all([
                 fetchDataSourceResponse(page),
-                cloudAccountsPage.clickCloudAccountLinkByName('SoftwareOne AWS')
+                cloudAccountsPage.clickCloudAccountLink(1)
             ]);
             dataSourceResponse = response;
         });

--- a/e2etests/tests/recommendations-tests.spec.ts
+++ b/e2etests/tests/recommendations-tests.spec.ts
@@ -6,7 +6,7 @@ import {debugLog} from "../utils/debug-logging";
 
 
 test.describe("[MPT-11310] Recommendations page tests", {tag: ["@ui", "@recommendations"]}, () => {
-
+  test.describe.configure({mode: 'default'});
   test.use({restoreSession: true});
 
   test.beforeEach(async ({recommendationsPage}) => {

--- a/e2etests/tests/resources-tests.spec.ts
+++ b/e2etests/tests/resources-tests.spec.ts
@@ -37,6 +37,7 @@ import { InterceptionEntry } from "../types/interceptor.types";
 
 test.describe("[MPT-11957] Resources page tests", { tag: ["@ui", "@resources"] }, () => {
   test.skip(process.env.USE_LIVE_DEMO === 'true', "Live demo environment is not supported by these tests");
+  test.describe.configure({ mode: 'default' });
   test.use({ restoreSession: true });
   let totalExpensesValue: number;
   let itemisedTotal: number;

--- a/e2etests/tests/resources-tests.spec.ts
+++ b/e2etests/tests/resources-tests.spec.ts
@@ -80,7 +80,7 @@ test.describe("[MPT-11957] Resources page tests", { tag: ["@ui", "@resources"] }
     });
 
     await test.step('Verify all filter buttons are displayed', async () => {
-      await expect(resourcesPage.allFilterBoxButtons).toHaveCount(20);
+      await expect(resourcesPage.allFilterBoxButtons).toHaveCount(17);
 
       const expectedFilters = [
         resourcesPage.suggestionsFilter,
@@ -99,9 +99,10 @@ test.describe("[MPT-11957] Resources page tests", { tag: ["@ui", "@resources"] }
         resourcesPage.withoutTagFilter,
         resourcesPage.paidNetworkTrafficFromFilter,
         resourcesPage.paidNetworkTrafficToFilter,
-        resourcesPage.k8sNodeFilter,
-        resourcesPage.k8sServiceFilter,
-        resourcesPage.k8sNamespaceFilter,
+        // Kubernetes filters are currently hidden
+        // resourcesPage.k8sNodeFilter,
+        // resourcesPage.k8sServiceFilter,
+        // resourcesPage.k8sNamespaceFilter,
       ];
 
       for (const filter of expectedFilters) {
@@ -696,9 +697,9 @@ test.describe("[MPT-11957] Resources page tests", { tag: ["@ui", "@resources"] }
 
 test.describe("[MPT-11957] Resources page mocked tests", { tag: ["@ui", "@resources"] }, () => {
   test.skip(process.env.USE_LIVE_DEMO === 'true', "Live demo environment is not supported by these tests");
+  test.describe.configure({mode: 'default'});
 
-
-  const apiInterceptions: InterceptionEntry[] = [
+    const apiInterceptions: InterceptionEntry[] = [
     {
       url: `/v2/organizations/[^/]+/summary_expenses`,
       mock: SummaryExpensesResponse
@@ -745,7 +746,7 @@ test.describe("[MPT-11957] Resources page mocked tests", { tag: ["@ui", "@resour
     }
   ];
 
-  test.use({ restoreSession: true, interceptAPI: { entries: apiInterceptions } });
+  test.use({ restoreSession: true, interceptAPI: { entries: apiInterceptions, forceFailure: false } });
 
   test.beforeEach('Login admin user', async ({ resourcesPage }) => {
     await test.step('Login admin user', async () => {

--- a/e2etests/tests/resources-tests.spec.ts
+++ b/e2etests/tests/resources-tests.spec.ts
@@ -100,7 +100,7 @@ test.describe("[MPT-11957] Resources page tests", { tag: ["@ui", "@resources"] }
         resourcesPage.withoutTagFilter,
         resourcesPage.paidNetworkTrafficFromFilter,
         resourcesPage.paidNetworkTrafficToFilter,
-        // Kubernetes filters are currently hidden
+        // Kubernetes filters are temporarily disabled
         // resourcesPage.k8sNodeFilter,
         // resourcesPage.k8sServiceFilter,
         // resourcesPage.k8sNamespaceFilter,

--- a/e2etests/utils/api-requests/interceptor.ts
+++ b/e2etests/utils/api-requests/interceptor.ts
@@ -1,61 +1,73 @@
-import {Page, expect} from "@playwright/test";
+import {Page, test} from "@playwright/test";
 import {debugLog} from "../debug-logging";
 import {InterceptionEntry} from "../../types/interceptor.types";
 import {createInterceptorId, interceptGraphQLRequest, interceptRESTRequest} from "./helpers";
 
-export async function apiInterceptors<T>(page: Page, config: InterceptionEntry[]): Promise<() => void> {
+/**
+ * Sets up API interceptors for Playwright tests and returns a function to verify if all interceptions occurred.
+ *
+ * @template T - Generic type parameter for flexibility.
+ * @param {Page} page - The Playwright `Page` object where the interceptors will be applied.
+ * @param {InterceptionEntry[]} config - Array of interception configurations, each specifying the URL, mock data, and whether it's a GraphQL request.
+ * @param {boolean} forceFailure - Determines whether the test should fail if some interceptions are not triggered.
+ * @returns {Promise<() => void>} - A function that verifies if all configured interceptions were triggered.
+ */
+export async function apiInterceptors<T>(page: Page, config: InterceptionEntry[], forceFailure: boolean): Promise<() => void> {
 
-  const interceptorHits = new Map<string, boolean>();
+    const interceptorHits = new Map<string, boolean>();
 
-  const createHitTracker = (id: string): () => void => {
-    debugLog(`(HIT) Request intercepted&mocked ${id}`);
-    return () => interceptorHits.set(id, true);
-  };
+    const createHitTracker = (id: string): () => void => {
+        debugLog(`(HIT) Request intercepted&mocked ${id}`);
+        return () => interceptorHits.set(id, true);
+    };
 
-  const interceptPromises = config.map(({url, mock, gql}, index) => {
-    const urlRegExp = new RegExp(url || "/api$");
-    const interceptorId = createInterceptorId(gql, url);
+    const interceptPromises = config.map(({url, mock, gql}, index) => {
+        const urlRegExp = new RegExp(url || "/api$");
+        const interceptorId = createInterceptorId(gql, url);
 
-    debugLog(`(${index + 1}/${config.length}) Setting up interceptor for ${interceptorId}`);
+        debugLog(`(${index + 1}/${config.length}) Setting up interceptor for ${interceptorId}`);
 
 
-    // Initialize hit tracking
-    interceptorHits.set(interceptorId, false);
+        // Initialize hit tracking
+        interceptorHits.set(interceptorId, false);
 
-    if(gql) {
-      return interceptGraphQLRequest(
-        page,
-        urlRegExp,
-        gql,
-        mock,
-        createHitTracker(interceptorId)
-      );
-    }else {
-      return interceptRESTRequest(
-        page,
-        urlRegExp,
-        mock,
-        createHitTracker(interceptorId)
-      );
-    }
-  });
+        if (gql) {
+            return interceptGraphQLRequest(
+                page,
+                urlRegExp,
+                gql,
+                mock,
+                createHitTracker(interceptorId)
+            );
+        } else {
+            return interceptRESTRequest(
+                page,
+                urlRegExp,
+                mock,
+                createHitTracker(interceptorId)
+            );
+        }
+    });
 
-  await Promise.all(interceptPromises);
+    await Promise.all(interceptPromises);
 
-  return () => {
-    const missingInterceptions = Array.from(interceptorHits.entries())
-      .filter(([_, wasHit]) => !wasHit)
-      .map(([id]) => id);
+    return () => {
+        const missingInterceptions = Array.from(interceptorHits.entries())
+            .filter(([_, wasHit]) => !wasHit)
+            .map(([id]) => id);
 
-    if (missingInterceptions.length > 0) {
-      const message =
-        `Test failed: ${missingInterceptions.length} API interception(s) never occurred:\n` +
-        missingInterceptions.map(x => `- ${x}`).join("\n");
+        if (missingInterceptions.length > 0) {
+            const message =
+                `${missingInterceptions.length} API interception(s) never occurred:\n` +
+                missingInterceptions.map(x => `- ${x}`).join("\n");
 
-      debugLog(message);
+            debugLog(message);
 
-      expect.soft(missingInterceptions, message).toHaveLength(0);
-    }
-  };
+            // E2E tests need to set up all interceptions at the test.describe level to avoid
+            // duplication for each test. However, not all tests will trigger all interceptions.
+            // Therefore, we make this optional to force failure or not.
+            test.fail(forceFailure, 'Some API interceptions were not triggered and forceFailure is set to true. See logs for details.');
+        }
+    };
 }
 


### PR DESCRIPTION

## Description
Added forceFailure option to API interception for flexible test failure behavior. Improved CloudAccountsPage to handle expandable cloud account links and updated related tests to use the new link click logic. Adjusted resource filter count and commented out hidden Kubernetes filters in resources page tests.


## Related issue number
https://softwareone.atlassian.net/browse/MPT-13272