### PR TITLE
feat(AWS Data Source): Disable AccountID changes

### DIFF
--- a/ngui/ui/src/components/CloudAccountDetails/CloudAccountDetails.tsx
+++ b/ngui/ui/src/components/CloudAccountDetails/CloudAccountDetails.tsx
@@ -53,7 +53,7 @@ const {
   PRICING: PRICING_TAB
 } = CLOUD_ACCOUNT_DETAILS_PAGE_TABS;
 
-const PageActionBar = ({ id, type, parentId, name, config, lastImportAt, isLoading }) => {
+const PageActionBar = ({ id, type, parentId, name, config, dataSourceProps, lastImportAt, isLoading }) => {
   const openSideModal = useOpenSideModal();
 
   // TODO: initial values from useDataSources are default ones, which means logo is empty, Icon is null, JSX error in console.
@@ -127,7 +127,7 @@ const PageActionBar = ({ id, type, parentId, name, config, lastImportAt, isLoadi
           dataTestId: "btn_update_data_source_credentials_modal",
           type: "button",
           isLoading,
-          action: () => openSideModal(UpdateDataSourceCredentialsModal, { name, id, type, config }),
+          action: () => openSideModal(UpdateDataSourceCredentialsModal, { name, id, type, config, dataSourceProps }),
           requiredActions: ["MANAGE_CLOUD_CREDENTIALS"],
           disabled: parentId,
           tooltip: {
@@ -382,6 +382,7 @@ const CloudAccountDetails = ({ data = {}, isLoading = false }) => {
         name={name}
         parentId={parentId}
         config={config}
+        dataSourceProps={{ accountId }}
         lastImportAt={lastImportAt}
         isLoading={isLoading}
       />

--- a/ngui/ui/src/components/SideModalManager/SideModals/UpdateDataSourceCredentialsModal.tsx
+++ b/ngui/ui/src/components/SideModalManager/SideModals/UpdateDataSourceCredentialsModal.tsx
@@ -23,6 +23,7 @@ class UpdateDataSourceCredentialsModal extends BaseSideModal {
         name={this.payload?.type}
         type={this.payload?.type}
         config={this.payload?.config}
+        dataSourceProps={this.payload?.dataSourceProps}
         closeSideModal={this.closeSideModal}
       />
     );

--- a/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/FormElements/Credentials/AwsCredentials.tsx
+++ b/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/FormElements/Credentials/AwsCredentials.tsx
@@ -63,7 +63,7 @@ const AwsCredentials = ({ config }) => {
       case "assumedRoleLinked":
         return (
           <AwsAssumedRoleInputs
-            readOnlyFields={config.assume_role_account_id ? [AWS_ROLE_CREDENTIALS_FIELD_NAMES.ASSUME_ROLE_ACCOUNT_ID] : []}
+            readOnlyFields={[AWS_ROLE_CREDENTIALS_FIELD_NAMES.ASSUME_ROLE_ACCOUNT_ID]}
             showAdvancedOptions={!config.linked}
           />
         );

--- a/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/UpdateDataSourceCredentialsForm.tsx
+++ b/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/UpdateDataSourceCredentialsForm.tsx
@@ -183,7 +183,7 @@ const UpdateCredentialsWarning = ({ type }) => {
   }
 };
 
-const getConfig = (type, config) => {
+const getConfig = (type, config, dataSourceProps) => {
   switch (type) {
     case AWS_CNR: {
       const billingBucketFields = {
@@ -208,6 +208,7 @@ const getConfig = (type, config) => {
 
           if (config.linked) {
             return {
+              [AWS_ROLE_CREDENTIALS_FIELD_NAMES.ASSUME_ROLE_ACCOUNT_ID]: dataSourceProps.accountId,
               [AWS_LINKED_CREDENTIALS_FIELD_NAMES.ACCESS_KEY_ID]: config.access_key_id,
               [AWS_LINKED_CREDENTIALS_FIELD_NAMES.SECRET_ACCESS_KEY]: ""
             };
@@ -508,13 +509,14 @@ const UpdateDataSourceCredentialsForm = ({
   id,
   type,
   config,
+  dataSourceProps,
   onSubmit,
   onCancel,
   isLoading = false
 }: UpdateDataSourceCredentialsFormProps) => {
   const { isRestricted, restrictionReasonMessage } = useOrganizationActionRestrictions();
 
-  const { getDefaultFormValues, parseFormDataToApiParams } = getConfig(type, config);
+  const { getDefaultFormValues, parseFormDataToApiParams } = getConfig(type, config, dataSourceProps);
 
   const methods = useForm({
     defaultValues: getDefaultFormValues()

--- a/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/types.ts
+++ b/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/types.ts
@@ -1,9 +1,11 @@
+import { DataSourceProperties } from "containers/UpdateDataSourceCredentialsContainer/types";
 import { TODO } from "utils/types";
 
 export type UpdateDataSourceCredentialsFormProps = {
   id: string;
   type: string;
   config: TODO;
+  dataSourceProps: DataSourceProperties;
   isLoading: boolean;
   onSubmit: (id: string, data: TODO) => void;
   onCancel: () => void;

--- a/ngui/ui/src/containers/UpdateDataSourceCredentialsContainer/UpdateDataSourceCredentialsContainer.tsx
+++ b/ngui/ui/src/containers/UpdateDataSourceCredentialsContainer/UpdateDataSourceCredentialsContainer.tsx
@@ -19,6 +19,7 @@ const UpdateDataSourceCredentialsContainer = ({
   id,
   type,
   config,
+  dataSourceProps,
   closeSideModal
 }: UpdateDataSourceCredentialsContainerProps) => {
   const refetch = useRefetchApis();
@@ -68,6 +69,7 @@ const UpdateDataSourceCredentialsContainer = ({
       id={id}
       type={type}
       config={config}
+      dataSourceProps={dataSourceProps}
       onSubmit={onSubmit}
       onCancel={closeSideModal}
       isLoading={loading}

--- a/ngui/ui/src/containers/UpdateDataSourceCredentialsContainer/types.ts
+++ b/ngui/ui/src/containers/UpdateDataSourceCredentialsContainer/types.ts
@@ -1,9 +1,14 @@
 import { TODO } from "utils/types";
 
+export type DataSourceProperties = {
+  accountId?: string;
+};
+
 export type UpdateDataSourceCredentialsContainerProps = {
   id: string;
   type: string;
   config: TODO;
+  dataSourceProps: DataSourceProperties;
   closeSideModal: () => void;
 };
 


### PR DESCRIPTION
## Description

Disable AccountID changes while migration auth type from Access Key to Assumed Role

<img width="620" height="926" alt="Screenshot" src="https://github.com/user-attachments/assets/bf5fa634-b95a-4516-85b0-320233c9d43c" />


MPT-16950

## Checklist

* [ ] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist
* [ ] New and existing unit tests pass locally