### PR TITLE
[BACKPORT] feat: update ExpensesBreakdownLayoutWrapper import in theme and adjust PieChart tooltip width

### DIFF
--- a/ngui/ui/src/components/PieChart/PieChart.tsx
+++ b/ngui/ui/src/components/PieChart/PieChart.tsx
@@ -71,6 +71,7 @@ const PieChart = ({
         animate={false}
         theme={{
           tooltip: {
+            minWidth: "250px",
             zIndex: theme.zIndex.tooltip
           }
         }}

--- a/ngui/ui/src/themes/finops/components/ExpensesBreakdown/ExpensesBreakdown.tsx
+++ b/ngui/ui/src/themes/finops/components/ExpensesBreakdown/ExpensesBreakdown.tsx
@@ -5,10 +5,10 @@ import ExpensesBreakdownActionBar from "@main/components/ExpensesBreakdown/Actio
 import ExpensesBreakdownBarChart from "@main/components/ExpensesBreakdown/BarChart";
 import ExpensesBreakdownBreakdownByButtonsGroup from "@main/components/ExpensesBreakdown/BreakdownByButtonsGroup";
 import ExpensesBreakdownByPeriodWidget from "@main/components/ExpensesBreakdown/BreakdownByPeriodWidget";
-import ExpensesBreakdownLayoutWrapper from "@main/components/ExpensesBreakdown/LayoutWrapper";
 import ExpensesBreakdownPieChart from "@main/components/ExpensesBreakdown/PieChart";
 import ExpensesBreakdownSummaryCards from "@main/components/ExpensesBreakdown/SummaryCards";
 import ExpensesBreakdownTableWidget from "@main/components/ExpensesBreakdown/TableWidget";
+import ExpensesBreakdownLayoutWrapper from "@theme/components/ExpensesBreakdown/layoutWrapper/ExpensesBreakdownLayoutWrapper";
 import LabelColon from "@theme/shared/components/LabelColon/LabelColon";
 import ResponsiveStack from "@theme/shared/components/ResponsiveStack/ResponsiveStack";
 import { MPT_SEMICOLON, MPT_SPACING_2 } from "@theme/utils/layouts";


### PR DESCRIPTION
## Description

<img width="450" height="479" alt="Screenshot 2026-02-17 at 09 49 32" src="https://github.com/user-attachments/assets/d9e4eb86-6506-48f1-8953-de4d4678ca05" />
<img width="1645" height="698" alt="Screenshot 2026-02-17 at 09 49 47" src="https://github.com/user-attachments/assets/e07860e4-c6a4-4ad8-8a2d-353bf9fa33a8" />


## Related issue number

<!-- Please link a pull request to an issue by using "fixes #10" style references to close the issue when this PR is merged. -->

## Special notes

<!-- Please provide additional information if required. -->

## Checklist

* [x] The pull request title is a good summary of the changes
* [x] Unit tests for the changes exist
* [ ] New and existing unit tests pass locally